### PR TITLE
feat: add automated IP2Location database updates

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,2 +1,7 @@
 SENTRY_DSN="<Optional Sentry DSN>"
 DEV_MODE="<Optional true/false>"
+
+CLOUDFLARE_API_TOKEN="<Cloudflare API token>"
+ACME_EMAIL="<ACME email for certificate management>"
+
+IP2LOCATION_TOKEN="<IP2Location API token>"

--- a/README.md
+++ b/README.md
@@ -125,6 +125,7 @@ DoT Block can be configured using the following command-line flags:
 | `--blocklist-url` | URL of the blocklist (wildcard hostname format). | `https://gitlab.com/hagezi/mirror/-/raw/main/dns-blocklists/wildcard/pro-onlydomains.txt` |
 | `--cron-schedule:cache-reaper` | Cron spec for cache reaper. | `@every 10m` |
 | `--cron-schedule:downloader` | Cron spec for reloading blocklist. | `@every 19h` |
+| `--cron-schedule:ip2location` | Cron spec for fetching IP2Location db. | `5 7 4 * *` (7:05am on the 4th of every month) |
 | `--data-dir` | Directory for persisting data (e.g. TLS certificate cache). | `./data` |
 | `--dev-mode` | Run the server in dev mode (no TLS, plain TCP). | `false` |
 | `--dns-port` | The port to run regular DNS (UDP/TCP) server on. | `53` |

--- a/internal/app.go
+++ b/internal/app.go
@@ -72,11 +72,10 @@ func (app *App) RunServer() error {
 	}
 	defer sentry.Flush(2 * time.Second)
 
-	timeout := 3 * time.Second
-	dnsClient, err := forwarder.NewRoundRobinClient(timeout, app.Upstreams...)
-	if err != nil {
-		return errors.Wrap(err, "failed to initialize upstream DNS client")
-	}
+	adapter := logging.NewCronLoggerAdapter(app.Logger, "cron")
+	crontab := cron.New(cron.WithChain(cron.Recover(adapter)), cron.WithLogger(adapter))
+	crontab.Start()
+	defer crontab.Stop()
 
 	geolocationDb := fmt.Sprintf("%s/ip2location/IP2LOCATION-LITE-DB1.BIN", app.DataDir)
 	if _, err := os.Stat(geolocationDb); os.IsNotExist(err) {
@@ -88,9 +87,14 @@ func (app *App) RunServer() error {
 	}
 
 	app.Logger.Info("Loading geolocation database", "file", geolocationDb)
-	geoIpDb, err := geoblock.NewGeoIpLookup(geolocationDb)
+	geoIpLookup, err := geoblock.NewGeoIpLookup(geolocationDb)
 	if err != nil {
 		return errors.Wrap(err, "failed to open geoblock database")
+	}
+
+	app.Logger.Info("Creating IP2Location updater cron job", "schedule", app.CronSchedule.IP2Location)
+	if _, err = crontab.AddJob(app.CronSchedule.IP2Location, geoblock.NewIp2LocationUpdaterCronJob(app.Logger, "DB1LITEBIN", app.DataDir, geoIpLookup)); err != nil {
+		return errors.Wrap(err, "failed to create IP2Location updater cron job")
 	}
 
 	allHosts := make([]string, 0)
@@ -104,11 +108,6 @@ func (app *App) RunServer() error {
 	}
 
 	blockList := blocklist.NewBlockList(allHosts, 0.0001, app.Logger)
-
-	adapter := logging.NewCronLoggerAdapter(app.Logger, "cron")
-	crontab := cron.New(cron.WithChain(cron.Recover(adapter)), cron.WithLogger(adapter))
-	crontab.Start()
-	defer crontab.Stop()
 
 	app.Logger.Info("Creating blocklist downloader cron job", "schedule", app.CronSchedule)
 	blocklistUpdater := blocklist.NewBlocklistUpdater(blockList, app.BlockListURLs)
@@ -151,23 +150,24 @@ func (app *App) RunServer() error {
 		}
 	}
 
+	timeout := 3 * time.Second
+	dnsClient, err := forwarder.NewRoundRobinClient(timeout, app.Upstreams...)
+	if err != nil {
+		return errors.Wrap(err, "failed to initialize upstream DNS client")
+	}
+
 	r, err := app.startHttpServer(dnsClient, blocklistUpdater)
 	if err != nil {
 		return errors.Wrap(err, "failed to initialize HTTP server")
 	}
 
-	dispatcher, err := forwarder.NewDNSDispatcher(dnsClient, blockList, geoIpDb, CACHE_SIZE, app.Logger, app.NoDnsLogging)
+	dispatcher, err := forwarder.NewDNSDispatcher(dnsClient, blockList, geoIpLookup, CACHE_SIZE, app.Logger, app.NoDnsLogging)
 	if err != nil {
 		return errors.Wrap(err, "failed to create dispatcher")
 	}
 	app.Logger.Info("Creating cache reaper cron job", "schedule", app.CronSchedule.CacheReaper)
 	if _, err = crontab.AddJob(app.CronSchedule.CacheReaper, forwarder.NewCacheReaperCronJob(dispatcher)); err != nil {
 		return errors.Wrap(err, "failed to create cache reaper cron job")
-	}
-
-	app.Logger.Info("Creating IP2Location updater cron job", "schedule", app.CronSchedule.IP2Location)
-	if _, err = crontab.AddJob(app.CronSchedule.IP2Location, geoblock.NewIp2LocationUpdaterCronJob(app.Logger, "DB1LITEBIN", app.DataDir, geoIpDb)); err != nil {
-		return errors.Wrap(err, "failed to create IP2Location updater cron job")
 	}
 
 	dnsPort := fmt.Sprintf(":%d", app.DnsPort)

--- a/internal/app.go
+++ b/internal/app.go
@@ -17,13 +17,13 @@ import (
 	sentrygin "github.com/getsentry/sentry-go/gin"
 	"github.com/gin-contrib/pprof"
 	"github.com/gin-gonic/gin"
-	"github.com/ip2location/ip2location-go/v9"
 	"github.com/joho/godotenv"
 	"github.com/libdns/cloudflare"
 	"github.com/miekg/dns"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"github.com/rm-hull/dot-block/internal/blocklist"
 	"github.com/rm-hull/dot-block/internal/forwarder"
+	"github.com/rm-hull/dot-block/internal/geoblock"
 	"github.com/rm-hull/dot-block/internal/logging"
 	"github.com/rm-hull/dot-block/internal/mobileconfig"
 	"github.com/rm-hull/godx"
@@ -49,6 +49,7 @@ type App struct {
 	CronSchedule  struct {
 		Downloader  string
 		CacheReaper string
+		IP2Location string
 	}
 	Logger       *slog.Logger
 	NoDnsLogging bool
@@ -77,13 +78,17 @@ func (app *App) RunServer() error {
 		return errors.Wrap(err, "failed to initialize upstream DNS client")
 	}
 
-	// _, err = geoblock.Fetch("DB1LITEBIN", app.DataDir, app.Logger)
-	// if err != nil {
-	// 	return errors.Wrap(err, "failed to download geoblock database")
-	// }
 	geolocationDb := fmt.Sprintf("%s/ip2location/IP2LOCATION-LITE-DB1.BIN", app.DataDir)
+	if _, err := os.Stat(geolocationDb); os.IsNotExist(err) {
+		app.Logger.Info("Geolocation database not found, downloading...")
+		_, err = geoblock.Fetch("DB1LITEBIN", app.DataDir, app.Logger)
+		if err != nil {
+			return errors.Wrap(err, "failed to download geoblock database")
+		}
+	}
+
 	app.Logger.Info("Loading geolocation database", "file", geolocationDb)
-	geoIpDb, err := ip2location.OpenDB(geolocationDb)
+	geoIpDb, err := geoblock.NewGeoIpLookup(geolocationDb)
 	if err != nil {
 		return errors.Wrap(err, "failed to open geoblock database")
 	}
@@ -158,6 +163,11 @@ func (app *App) RunServer() error {
 	app.Logger.Info("Creating cache reaper cron job", "schedule", app.CronSchedule.CacheReaper)
 	if _, err = crontab.AddJob(app.CronSchedule.CacheReaper, forwarder.NewCacheReaperCronJob(dispatcher)); err != nil {
 		return errors.Wrap(err, "failed to create cache reaper cron job")
+	}
+
+	app.Logger.Info("Creating IP2Location updater cron job", "schedule", app.CronSchedule.IP2Location)
+	if _, err = crontab.AddJob(app.CronSchedule.IP2Location, geoblock.NewIp2LocationUpdaterCronJob(app.Logger, "DB1LITEBIN", app.DataDir, geoIpDb)); err != nil {
+		return errors.Wrap(err, "failed to create IP2Location updater cron job")
 	}
 
 	dnsPort := fmt.Sprintf(":%d", app.DnsPort)

--- a/internal/forwarder/dispatcher.go
+++ b/internal/forwarder/dispatcher.go
@@ -68,7 +68,7 @@ func (d *DNSDispatcher) HandleDNSRequest(writer dns.ResponseWriter, req *dns.Msg
 		d.metrics.RequestLatency.Observe(duration)
 		d.metrics.RequestCounts.WithLabelValues("total").Inc()
 
-		loc, err := d.geoIpLookup.Get_all(ipAddr)
+		loc, err := d.geoIpLookup.GetAll(ipAddr)
 		if err != nil {
 			requestLogger.Warn("failed to get geolocation for client IP", "error", err)
 		} else {

--- a/internal/forwarder/dispatcher_test.go
+++ b/internal/forwarder/dispatcher_test.go
@@ -23,9 +23,13 @@ type MockGeoIpLookup struct {
 	mock.Mock
 }
 
-func (m *MockGeoIpLookup) Get_all(ipAddress string) (ip2location.IP2Locationrecord, error) {
+func (m *MockGeoIpLookup) GetAll(ipAddress string) (ip2location.IP2Locationrecord, error) {
 	args := m.Called(ipAddress)
 	return args.Get(0).(ip2location.IP2Locationrecord), args.Error(1)
+}
+
+func (m *MockGeoIpLookup) Reopen() error {
+	return nil
 }
 
 // MockResponseWriter is a mock implementation of dns.ResponseWriter.
@@ -86,7 +90,7 @@ func TestDNSDispatcher_HandleDNSRequest_Allowed(t *testing.T) {
 	assert.NoError(t, err)
 
 	mockGeo := new(MockGeoIpLookup)
-	mockGeo.On("Get_all", mock.Anything).Return(ip2location.IP2Locationrecord{}, nil)
+	mockGeo.On("GetAll", mock.Anything).Return(ip2location.IP2Locationrecord{}, nil)
 
 	dispatcher, err := NewDNSDispatcher(dnsClient, blockList, mockGeo, 100, logger, false)
 	assert.NoError(t, err)
@@ -124,7 +128,7 @@ func TestDNSDispatcher_HandleDNSRequest_Blocked(t *testing.T) {
 	assert.NoError(t, err)
 
 	mockGeo := new(MockGeoIpLookup)
-	mockGeo.On("Get_all", mock.Anything).Return(ip2location.IP2Locationrecord{}, nil)
+	mockGeo.On("GetAll", mock.Anything).Return(ip2location.IP2Locationrecord{}, nil)
 
 	dispatcher, err := NewDNSDispatcher(dnsClient, blockList, mockGeo, 100, logger, false)
 	assert.NoError(t, err)
@@ -163,7 +167,7 @@ func TestDNSDispatcher_HandleDNSRequest_MultipleQuestions(t *testing.T) {
 	assert.NoError(t, err)
 
 	mockGeo := new(MockGeoIpLookup)
-	mockGeo.On("Get_all", mock.Anything).Return(ip2location.IP2Locationrecord{}, nil)
+	mockGeo.On("GetAll", mock.Anything).Return(ip2location.IP2Locationrecord{}, nil)
 
 	dispatcher, err := NewDNSDispatcher(dnsClient, blockList, mockGeo, 100, logger, false)
 	assert.NoError(t, err)
@@ -214,7 +218,7 @@ func TestDNSDispatcher_HandleDNSRequest_CacheHit(t *testing.T) {
 	assert.NoError(t, err)
 
 	mockGeo := new(MockGeoIpLookup)
-	mockGeo.On("Get_all", mock.Anything).Return(ip2location.IP2Locationrecord{}, nil)
+	mockGeo.On("GetAll", mock.Anything).Return(ip2location.IP2Locationrecord{}, nil)
 
 	dispatcher, err := NewDNSDispatcher(dnsClient, blockList, mockGeo, 100, logger, false)
 	assert.NoError(t, err)
@@ -269,7 +273,7 @@ func TestDNSDispatcher_ResolveUpstream_BadRCode(t *testing.T) {
 	assert.NoError(t, err)
 
 	mockGeo := new(MockGeoIpLookup)
-	mockGeo.On("Get_all", mock.Anything).Return(ip2location.IP2Locationrecord{}, nil)
+	mockGeo.On("GetAll", mock.Anything).Return(ip2location.IP2Locationrecord{}, nil)
 
 	dispatcher, err := NewDNSDispatcher(dnsClient, blockList, mockGeo, 100, logger, false)
 	require.NoError(t, err)
@@ -303,7 +307,7 @@ func TestDNSDispatcher_QueryLogging(t *testing.T) {
 	t.Run("Logging disabled", func(t *testing.T) {
 		logBuf.Reset()
 		mockGeo := new(MockGeoIpLookup)
-		mockGeo.On("Get_all", mock.Anything).Return(ip2location.IP2Locationrecord{}, nil)
+		mockGeo.On("GetAll", mock.Anything).Return(ip2location.IP2Locationrecord{}, nil)
 
 		dispatcher, err := NewDNSDispatcher(dnsClient, blockList, mockGeo, 100, logger, true)
 		require.NoError(t, err)
@@ -321,7 +325,7 @@ func TestDNSDispatcher_QueryLogging(t *testing.T) {
 	t.Run("Logging enabled", func(t *testing.T) {
 		logBuf.Reset()
 		mockGeo := new(MockGeoIpLookup)
-		mockGeo.On("Get_all", mock.Anything).Return(ip2location.IP2Locationrecord{}, nil)
+		mockGeo.On("GetAll", mock.Anything).Return(ip2location.IP2Locationrecord{}, nil)
 
 		dispatcher, err := NewDNSDispatcher(dnsClient, blockList, mockGeo, 100, logger, false)
 		require.NoError(t, err)

--- a/internal/geoblock/service.go
+++ b/internal/geoblock/service.go
@@ -1,7 +1,57 @@
 package geoblock
 
-import "github.com/ip2location/ip2location-go/v9"
+import (
+	"sync"
+
+	"github.com/ip2location/ip2location-go/v9"
+)
 
 type GeoIpLookup interface {
-	Get_all(ipAddress string) (ip2location.IP2Locationrecord, error)
+	Reopen() error
+	GetAll(ipAddress string) (ip2location.IP2Locationrecord, error)
+}
+
+type geoBlocker struct {
+	path string
+	db   *ip2location.DB
+	mu   sync.RWMutex
+}
+
+func NewGeoIpLookup(path string) (GeoIpLookup, error) {
+	db, err := ip2location.OpenDB(path)
+	if err != nil {
+		return nil, err
+	}
+	return &geoBlocker{
+		path: path,
+		db:   db,
+	}, nil
+}
+
+func (g *geoBlocker) Reopen() error {
+	newDb, err := ip2location.OpenDB(g.path)
+	if err != nil {
+		return err
+	}
+
+	g.mu.Lock()
+	oldDb := g.db
+	g.db = newDb
+	g.mu.Unlock()
+
+	if oldDb != nil {
+		oldDb.Close()
+	}
+	return nil
+}
+
+func (g *geoBlocker) GetAll(ipAddress string) (ip2location.IP2Locationrecord, error) {
+	g.mu.RLock()
+	defer g.mu.RUnlock()
+
+	if g.db == nil {
+		return ip2location.IP2Locationrecord{}, nil
+	}
+
+	return g.db.Get_all(ipAddress)
 }

--- a/internal/geoblock/service.go
+++ b/internal/geoblock/service.go
@@ -3,6 +3,7 @@ package geoblock
 import (
 	"sync"
 
+	"github.com/cockroachdb/errors"
 	"github.com/ip2location/ip2location-go/v9"
 )
 
@@ -50,7 +51,7 @@ func (g *geoBlocker) GetAll(ipAddress string) (ip2location.IP2Locationrecord, er
 	defer g.mu.RUnlock()
 
 	if g.db == nil {
-		return ip2location.IP2Locationrecord{}, nil
+		return ip2location.IP2Locationrecord{}, errors.New("geoblock database not initialized")
 	}
 
 	return g.db.Get_all(ipAddress)

--- a/internal/geoblock/update.go
+++ b/internal/geoblock/update.go
@@ -17,23 +17,28 @@ import (
 )
 
 type Ip2LocationUpdater struct {
-	logger  *slog.Logger
-	fileId  string
-	dataDir string
+	logger      *slog.Logger
+	fileId      string
+	dataDir     string
+	geoIpLookup GeoIpLookup
 }
 
-func NewIp2LocationUpdaterCronJob(logger *slog.Logger, fileId string, dataDir string) *Ip2LocationUpdater {
+func NewIp2LocationUpdaterCronJob(logger *slog.Logger, fileId string, dataDir string, geoIpLookup GeoIpLookup) *Ip2LocationUpdater {
 	return &Ip2LocationUpdater{
 		logger:  logger,
 		fileId:  fileId,
 		dataDir: dataDir,
+		geoIpLookup: geoIpLookup,
 	}
 }
 
 func (job *Ip2LocationUpdater) Run() {
-	_, err := Fetch(job.fileId, job.dataDir, job.logger)
-	if err != nil {
+	if _, err := Fetch(job.fileId, job.dataDir, job.logger); err != nil {
 		job.logger.Error("failed to download ip2location list for cron reload", "error", err)
+	}
+
+	if err := job.geoIpLookup.Reopen(); err != nil {
+		job.logger.Error("failed to reopen geoblock database after update", "error", err)
 	}
 }
 

--- a/main.go
+++ b/main.go
@@ -11,6 +11,7 @@ import (
 
 const DEFAULT_DOWNLOADER_CRON_SCHEDULE = "@every 19h"
 const DEFAULT_CACHE_REAPER_CRON_SCHEDULE = "@every 10m"
+const DEFAULT_IP2LOCATION_CRON_SCHEDULE = "5 7 4 * *" // 7:05am on the 4th of every month
 
 var DEFAULT_BLOCKLIST_URLS = []string{
 	"https://gitlab.com/hagezi/mirror/-/raw/main/dns-blocklists/wildcard/pro-onlydomains.txt", // Hagezi Pro blocklist
@@ -69,6 +70,7 @@ func main() {
 	rootCmd.Flags().StringVar(&app.MetricsAuth, "metrics-auth", "", "Credentials for basic auth on /metrics (format: `user:pass`)")
 	rootCmd.Flags().StringVar(&app.CronSchedule.Downloader, "cron-schedule:downloader", DEFAULT_DOWNLOADER_CRON_SCHEDULE, "cron spec for reloading blocklist")
 	rootCmd.Flags().StringVar(&app.CronSchedule.CacheReaper, "cron-schedule:cache-reaper", DEFAULT_CACHE_REAPER_CRON_SCHEDULE, "cron spec for cache reaper")
+	rootCmd.Flags().StringVar(&app.CronSchedule.IP2Location, "cron-schedule:ip2location", DEFAULT_IP2LOCATION_CRON_SCHEDULE, "cron spec for Ip2location downloader")
 
 	if err := rootCmd.Execute(); err != nil {
 		app.Logger.Error("Failed to execute command", "error", err)


### PR DESCRIPTION
- Introduce `GeoIpLookup` wrapper with `RWMutex` to support hot-reloading
  of the IP2Location database.
- Add an automated cron job to fetch and reload the database monthly.
- Update `.env.example` to include necessary API tokens.
- Refactor `GetAll` method usage across the codebase.

```mermaid
sequenceDiagram
    participant C as Cron Job
    participant F as Fetcher
    participant G as GeoIpLookup
    participant DB as File System

    C->>F: Run()
    F->>DB: Download latest .BIN file
    C->>G: Reopen()
    G->>DB: Open new .BIN file
    G->>G: Swap DB handles
    G->>G: Close old DB handle
```