### PR TITLE
feat: add `--cache-ttl-floor` for non-sensitive DNS records

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,7 @@ DoT Block can be configured using the following command-line flags:
 
 | Flag | Description | Default |
 | :--- | :--- | :--- |
+| `--cache-ttl-floor` | Minimum TTL for cached entries (in seconds). If a response is not "freshness sensitive" (e.g. contains `ocsp`, `crl`, `pki` or is `SOA`/`TXT`), the cache TTL will be at least this value. | `3600` |
 | `--allowed-host` | List of domains used for the CertManager allow policy. | `nil` |
 | `--blocklist-url` | List of URL blocklists (wildcard hostname format). | `https://codeberg.org/hagezi/mirror2/raw/branch/main/dns-blocklists/hosts/pro.txt`, `https://raw.githubusercontent.com/rm-hull/dot-block/refs/heads/main/data/blocklist.txt"` |
 | `--cron-schedule:cache-reaper` | Cron spec for cache reaper. | `@every 10m` |

--- a/internal/app.go
+++ b/internal/app.go
@@ -51,8 +51,9 @@ type App struct {
 		CacheReaper string
 		IP2Location string
 	}
-	Logger   *slog.Logger
-	LogLevel string
+	CacheTtlFloor int
+	Logger        *slog.Logger
+	LogLevel      string
 }
 
 func (app *App) RunServer() error {
@@ -161,7 +162,7 @@ func (app *App) RunServer() error {
 		return errors.Wrap(err, "failed to initialize HTTP server")
 	}
 
-	dispatcher, err := forwarder.NewDNSDispatcher(dnsClient, blockList, geoIpLookup, CACHE_SIZE, app.Logger)
+	dispatcher, err := forwarder.NewDNSDispatcher(dnsClient, blockList, geoIpLookup, CACHE_SIZE, app.CacheTtlFloor, app.Logger)
 	if err != nil {
 		return errors.Wrap(err, "failed to create dispatcher")
 	}

--- a/internal/app.go
+++ b/internal/app.go
@@ -51,7 +51,7 @@ type App struct {
 		CacheReaper string
 		IP2Location string
 	}
-	CacheTtlFloor int
+	CacheTtlFloor time.Duration
 	Logger        *slog.Logger
 	LogLevel      string
 }

--- a/internal/forwarder/dispatcher.go
+++ b/internal/forwarder/dispatcher.go
@@ -35,6 +35,10 @@ func NewDNSDispatcher(
 	logger *slog.Logger,
 ) (*DNSDispatcher, error) {
 
+	if cacheTtlFloor < 0 {
+		return nil, errors.New("cacheTtlFloor cannot be negative")
+	}
+
 	cache := cache.NewCache[string, []dns.RR]().WithMaxKeys(maxSize).WithLRU()
 	metrics, err := metrics.NewDNSMetrics(cache)
 	if err != nil {

--- a/internal/forwarder/dispatcher.go
+++ b/internal/forwarder/dispatcher.go
@@ -3,6 +3,7 @@ package forwarder
 import (
 	"log/slog"
 	"net"
+	"strings"
 	"time"
 
 	"github.com/cockroachdb/errors"
@@ -15,10 +16,11 @@ import (
 )
 
 type DNSDispatcher struct {
-	dnsClient   *RoundRobinClient
-	defaultTTL  float64
-	cache       cache.Cache[string, []dns.RR]
-	blockList   *blocklist.BlockList
+	dnsClient     *RoundRobinClient
+	defaultTTL    float64
+	cacheTtlFloor int
+	cache         cache.Cache[string, []dns.RR]
+	blockList     *blocklist.BlockList
 	geoIpLookup geoblock.GeoIpLookup
 	metrics     *metrics.DnsMetrics
 	logger      *slog.Logger
@@ -29,6 +31,7 @@ func NewDNSDispatcher(
 	blockList *blocklist.BlockList,
 	geoIpLookup geoblock.GeoIpLookup,
 	maxSize int,
+	cacheTtlFloor int,
 	logger *slog.Logger,
 ) (*DNSDispatcher, error) {
 
@@ -39,13 +42,14 @@ func NewDNSDispatcher(
 	}
 
 	return &DNSDispatcher{
-		dnsClient:   dnsClient,
-		defaultTTL:  300, // TODO: pass in
-		cache:       cache,
-		blockList:   blockList,
-		geoIpLookup: geoIpLookup,
-		metrics:     metrics,
-		logger:      logger,
+		dnsClient:     dnsClient,
+		defaultTTL:    300, // TODO: pass in
+		cacheTtlFloor: cacheTtlFloor,
+		cache:         cache,
+		blockList:     blockList,
+		geoIpLookup:   geoIpLookup,
+		metrics:       metrics,
+		logger:        logger,
 	}, nil
 }
 
@@ -189,13 +193,38 @@ func (d *DNSDispatcher) resolveUpstream(unansweredQuestions []dns.Question, req 
 		key := getCacheKey(&q)
 		if answersForQuestion, ok := answerMap[key]; ok {
 			upstreamTTL := answersForQuestion[0].Header().Ttl
-			d.cache.Set(key, answersForQuestion, time.Duration(upstreamTTL)*time.Second)
+			effectiveTTL := time.Duration(upstreamTTL) * time.Second
+
+			if !d.isFreshnessSensitive(&q) && upstreamTTL < uint32(d.cacheTtlFloor) {
+				effectiveTTL = time.Duration(d.cacheTtlFloor) * time.Second
+			}
+
+			d.cache.Set(key, answersForQuestion, effectiveTTL)
 			d.metrics.UpstreamTTLs.WithLabelValues(getQueryType(&q)).Observe(float64(upstreamTTL))
 		}
 	}
 
 	return upstreamReq.Rcode, upstreamResp.Answer, nil
 }
+
+func (d *DNSDispatcher) isFreshnessSensitive(q *dns.Question) bool {
+	// Check query type
+	switch q.Qtype {
+	case dns.TypeSOA, dns.TypeTXT:
+		return true
+	}
+
+	// Check name patterns
+	lower := strings.ToLower(q.Name)
+	for _, pattern := range freshnessSensitive {
+		if strings.Contains(lower, pattern) {
+			return true
+		}
+	}
+	return false
+}
+
+var freshnessSensitive = []string{"ocsp", "crl", "pki"}
 
 func (d *DNSDispatcher) updateClientCount(writer dns.ResponseWriter) error {
 	remoteAddr := writer.RemoteAddr().String()

--- a/internal/forwarder/dispatcher.go
+++ b/internal/forwarder/dispatcher.go
@@ -18,7 +18,7 @@ import (
 type DNSDispatcher struct {
 	dnsClient     *RoundRobinClient
 	defaultTTL    float64
-	cacheTtlFloor int
+	cacheTtlFloor time.Duration
 	cache         cache.Cache[string, []dns.RR]
 	blockList     *blocklist.BlockList
 	geoIpLookup geoblock.GeoIpLookup
@@ -31,7 +31,7 @@ func NewDNSDispatcher(
 	blockList *blocklist.BlockList,
 	geoIpLookup geoblock.GeoIpLookup,
 	maxSize int,
-	cacheTtlFloor int,
+	cacheTtlFloor time.Duration,
 	logger *slog.Logger,
 ) (*DNSDispatcher, error) {
 
@@ -195,8 +195,8 @@ func (d *DNSDispatcher) resolveUpstream(unansweredQuestions []dns.Question, req 
 			upstreamTTL := answersForQuestion[0].Header().Ttl
 			effectiveTTL := time.Duration(upstreamTTL) * time.Second
 
-			if !d.isFreshnessSensitive(&q) && upstreamTTL < uint32(d.cacheTtlFloor) {
-				effectiveTTL = time.Duration(d.cacheTtlFloor) * time.Second
+			if !d.isFreshnessSensitive(&q) && time.Duration(upstreamTTL)*time.Second < d.cacheTtlFloor {
+				effectiveTTL = d.cacheTtlFloor
 			}
 
 			d.cache.Set(key, answersForQuestion, effectiveTTL)

--- a/internal/forwarder/dispatcher.go
+++ b/internal/forwarder/dispatcher.go
@@ -199,7 +199,7 @@ func (d *DNSDispatcher) resolveUpstream(unansweredQuestions []dns.Question, req 
 			upstreamTTL := answersForQuestion[0].Header().Ttl
 			effectiveTTL := time.Duration(upstreamTTL) * time.Second
 
-			if !d.isFreshnessSensitive(&q) && time.Duration(upstreamTTL)*time.Second < d.cacheTtlFloor {
+			if !d.isFreshnessSensitive(&q) && effectiveTTL < d.cacheTtlFloor {
 				effectiveTTL = d.cacheTtlFloor
 			}
 

--- a/internal/forwarder/dispatcher_test.go
+++ b/internal/forwarder/dispatcher_test.go
@@ -92,7 +92,7 @@ func TestDNSDispatcher_HandleDNSRequest_Allowed(t *testing.T) {
 	mockGeo := new(MockGeoIpLookup)
 	mockGeo.On("GetAll", mock.Anything).Return(ip2location.IP2Locationrecord{}, nil)
 
-	dispatcher, err := NewDNSDispatcher(dnsClient, blockList, mockGeo, 100, logger)
+	dispatcher, err := NewDNSDispatcher(dnsClient, blockList, mockGeo, 100, 1*time.Minute, logger)
 	assert.NoError(t, err)
 
 	req := new(dns.Msg)
@@ -130,7 +130,7 @@ func TestDNSDispatcher_HandleDNSRequest_Blocked(t *testing.T) {
 	mockGeo := new(MockGeoIpLookup)
 	mockGeo.On("GetAll", mock.Anything).Return(ip2location.IP2Locationrecord{}, nil)
 
-	dispatcher, err := NewDNSDispatcher(dnsClient, blockList, mockGeo, 100, logger)
+	dispatcher, err := NewDNSDispatcher(dnsClient, blockList, mockGeo, 100, 1*time.Minute, logger)
 	assert.NoError(t, err)
 
 	req := new(dns.Msg)
@@ -169,7 +169,7 @@ func TestDNSDispatcher_HandleDNSRequest_MultipleQuestions(t *testing.T) {
 	mockGeo := new(MockGeoIpLookup)
 	mockGeo.On("GetAll", mock.Anything).Return(ip2location.IP2Locationrecord{}, nil)
 
-	dispatcher, err := NewDNSDispatcher(dnsClient, blockList, mockGeo, 100, logger)
+	dispatcher, err := NewDNSDispatcher(dnsClient, blockList, mockGeo, 100, 1*time.Minute, logger)
 	assert.NoError(t, err)
 
 	req := new(dns.Msg)
@@ -220,7 +220,7 @@ func TestDNSDispatcher_HandleDNSRequest_CacheHit(t *testing.T) {
 	mockGeo := new(MockGeoIpLookup)
 	mockGeo.On("GetAll", mock.Anything).Return(ip2location.IP2Locationrecord{}, nil)
 
-	dispatcher, err := NewDNSDispatcher(dnsClient, blockList, mockGeo, 100, logger)
+	dispatcher, err := NewDNSDispatcher(dnsClient, blockList, mockGeo, 100, 1*time.Minute, logger)
 	assert.NoError(t, err)
 
 	req := new(dns.Msg)
@@ -275,7 +275,7 @@ func TestDNSDispatcher_ResolveUpstream_BadRCode(t *testing.T) {
 	mockGeo := new(MockGeoIpLookup)
 	mockGeo.On("GetAll", mock.Anything).Return(ip2location.IP2Locationrecord{}, nil)
 
-	dispatcher, err := NewDNSDispatcher(dnsClient, blockList, mockGeo, 100, logger)
+	dispatcher, err := NewDNSDispatcher(dnsClient, blockList, mockGeo, 100, 1*time.Minute, logger)
 	require.NoError(t, err)
 
 	req := new(dns.Msg)
@@ -309,7 +309,7 @@ func TestDNSDispatcher_QueryLogging(t *testing.T) {
 		mockGeo := new(MockGeoIpLookup)
 		mockGeo.On("GetAll", mock.Anything).Return(ip2location.IP2Locationrecord{}, nil)
 
-		dispatcher, err := NewDNSDispatcher(dnsClient, blockList, mockGeo, 100, logger)
+		dispatcher, err := NewDNSDispatcher(dnsClient, blockList, mockGeo, 100, 1*time.Minute, logger)
 		require.NoError(t, err)
 
 		req := new(dns.Msg)
@@ -328,7 +328,7 @@ func TestDNSDispatcher_QueryLogging(t *testing.T) {
 		mockGeo := new(MockGeoIpLookup)
 		mockGeo.On("GetAll", mock.Anything).Return(ip2location.IP2Locationrecord{}, nil)
 
-		dispatcher, err := NewDNSDispatcher(dnsClient, blockList, mockGeo, 100, logger)
+		dispatcher, err := NewDNSDispatcher(dnsClient, blockList, mockGeo, 100, 1*time.Minute, logger)
 		require.NoError(t, err)
 
 		req := new(dns.Msg)

--- a/internal/forwarder/dispatcher_test.go
+++ b/internal/forwarder/dispatcher_test.go
@@ -291,6 +291,18 @@ func TestDNSDispatcher_ResolveUpstream_BadRCode(t *testing.T) {
 	assert.Equal(t, dns.RcodeRefused, writer.WrittenMsg.Rcode)
 }
 
+func TestNewDNSDispatcher_NegativeCacheTtlFloor(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	blockList := blocklist.NewBlockList([]string{"ads.0xbt.net"}, 0.0001, logger)
+	dnsClient, _ := NewRoundRobinClient(2*time.Second, "8.8.8.8:53")
+	mockGeo := new(MockGeoIpLookup)
+
+	dispatcher, err := NewDNSDispatcher(dnsClient, blockList, mockGeo, 100, -1*time.Second, logger)
+	assert.Error(t, err)
+	assert.Nil(t, dispatcher)
+	assert.Contains(t, err.Error(), "cacheTtlFloor cannot be negative")
+}
+
 func TestDNSDispatcher_QueryLogging(t *testing.T) {
 	var logBuf bytes.Buffer
 

--- a/main.go
+++ b/main.go
@@ -4,6 +4,7 @@ import (
 	"log/slog"
 	"os"
 	"strings"
+	"time"
 
 	"github.com/rm-hull/dot-block/internal"
 	"github.com/rm-hull/dot-block/internal/logging"
@@ -90,7 +91,7 @@ func main() {
 	rootCmd.Flags().StringVar(&app.CronSchedule.Downloader, "cron-schedule:downloader", DEFAULT_DOWNLOADER_CRON_SCHEDULE, "cron spec for reloading blocklist")
 	rootCmd.Flags().StringVar(&app.CronSchedule.CacheReaper, "cron-schedule:cache-reaper", DEFAULT_CACHE_REAPER_CRON_SCHEDULE, "cron spec for cache reaper")
 	rootCmd.Flags().StringVar(&app.CronSchedule.IP2Location, "cron-schedule:ip2location", DEFAULT_IP2LOCATION_CRON_SCHEDULE, "cron spec for Ip2location downloader")
-	rootCmd.Flags().IntVar(&app.CacheTtlFloor, "cache-ttl-floor", 3600, "Minimum TTL for cached entries")
+	rootCmd.Flags().DurationVar(&app.CacheTtlFloor, "cache-ttl-floor", 3600*time.Second, "Minimum TTL for cached entries")
 
 	if err := rootCmd.Execute(); err != nil {
 		app.Logger.Error("Failed to execute command", "error", err)

--- a/main.go
+++ b/main.go
@@ -90,6 +90,7 @@ func main() {
 	rootCmd.Flags().StringVar(&app.CronSchedule.Downloader, "cron-schedule:downloader", DEFAULT_DOWNLOADER_CRON_SCHEDULE, "cron spec for reloading blocklist")
 	rootCmd.Flags().StringVar(&app.CronSchedule.CacheReaper, "cron-schedule:cache-reaper", DEFAULT_CACHE_REAPER_CRON_SCHEDULE, "cron spec for cache reaper")
 	rootCmd.Flags().StringVar(&app.CronSchedule.IP2Location, "cron-schedule:ip2location", DEFAULT_IP2LOCATION_CRON_SCHEDULE, "cron spec for Ip2location downloader")
+	rootCmd.Flags().IntVar(&app.CacheTtlFloor, "cache-ttl-floor", 3600, "Minimum TTL for cached entries")
 
 	if err := rootCmd.Execute(); err != nil {
 		app.Logger.Error("Failed to execute command", "error", err)


### PR DESCRIPTION
Introduces a configurable minimum TTL for cached DNS entries. Entries not considered "freshness sensitive" (e.g., SOA, TXT, or those matching OCSP/CRL/PKI patterns) will now respect this floor to improve cache hit rates for static records.