### PR TITLE
refactor: change blocklist_age to GaugeFunc

### DIFF
--- a/internal/metrics/blocklist_metrics.go
+++ b/internal/metrics/blocklist_metrics.go
@@ -10,7 +10,7 @@ import (
 
 type BlockListMetrics struct {
 	size        prometheus.Gauge
-	age         prometheus.CounterFunc
+	age         prometheus.GaugeFunc
 	reloads     prometheus.Counter
 	lastUpdated time.Time
 }
@@ -25,7 +25,7 @@ func NewBlockListMetrics() (*BlockListMetrics, error) {
 		Help: "The number of entries in the blocklist",
 	})
 
-	metrics.age = prometheus.NewCounterFunc(prometheus.CounterOpts{
+	metrics.age = prometheus.NewGaugeFunc(prometheus.GaugeOpts{
 		Name: "blocklist_age",
 		Help: "The age (in seconds) since the blocklist was last reloaded",
 	}, func() float64 {

--- a/internal/metrics/blocklist_metrics.go
+++ b/internal/metrics/blocklist_metrics.go
@@ -2,6 +2,7 @@ package metrics
 
 import (
 	"math"
+	"sync"
 	"time"
 
 	"github.com/cockroachdb/errors"
@@ -9,6 +10,7 @@ import (
 )
 
 type BlockListMetrics struct {
+	mu          sync.RWMutex
 	size        prometheus.Gauge
 	age         prometheus.GaugeFunc
 	reloads     prometheus.Counter
@@ -29,7 +31,10 @@ func NewBlockListMetrics() (*BlockListMetrics, error) {
 		Name: "blocklist_age",
 		Help: "The age (in seconds) since the blocklist was last reloaded",
 	}, func() float64 {
-		return math.Round(time.Since(metrics.lastUpdated).Seconds())
+		metrics.mu.RLock()
+		lastUpdated := metrics.lastUpdated
+		metrics.mu.RUnlock()
+		return math.Round(time.Since(lastUpdated).Seconds())
 	})
 
 	metrics.reloads = prometheus.NewCounter(prometheus.CounterOpts{
@@ -45,7 +50,9 @@ func NewBlockListMetrics() (*BlockListMetrics, error) {
 }
 
 func (m *BlockListMetrics) Update(n uint) {
+	m.mu.Lock()
 	m.lastUpdated = time.Now()
+	m.mu.Unlock()
 	m.size.Set(float64(n))
 	m.reloads.Inc()
 }


### PR DESCRIPTION
Converted `blocklist_age` from a CounterFunc to a GaugeFunc. Since the metric represents an absolute duration (age) rather than a cumulative event count, a Gauge is semantically correct for Prometheus reporting.