### PR TITLE
feat: track DNS request source in metrics and logs

### DIFF
--- a/internal/app.go
+++ b/internal/app.go
@@ -192,7 +192,7 @@ func (app *App) RunServer() error {
 		return (&dns.Server{
 			Addr:    fmt.Sprintf(":%d", app.DnsPort),
 			Net:     "udp",
-			Handler: dns.HandlerFunc(dispatcher.HandleDNSRequest),
+			Handler: dns.HandlerFunc(dispatcher.HandleDNSRequest(forwarder.SourceUDP)),
 		}).ListenAndServe()
 	})
 
@@ -205,7 +205,7 @@ func (app *App) RunServer() error {
 		return (&dns.Server{
 			Addr:    fmt.Sprintf(":%d", app.DnsPort),
 			Net:     "tcp",
-			Handler: dns.HandlerFunc(dispatcher.HandleDNSRequest),
+			Handler: dns.HandlerFunc(dispatcher.HandleDNSRequest(forwarder.SourceTCP)),
 		}).ListenAndServe()
 	})
 
@@ -243,7 +243,7 @@ func (app *App) RunServer() error {
 			Addr:     dotPort,
 			Net:      "tcp",
 			Listener: listener,
-			Handler:  dns.HandlerFunc(dispatcher.HandleDNSRequest),
+			Handler:  dns.HandlerFunc(dispatcher.HandleDNSRequest(forwarder.SourceDoT)),
 		}).ActivateAndServe()
 	})
 

--- a/internal/forwarder/dispatcher.go
+++ b/internal/forwarder/dispatcher.go
@@ -15,6 +15,22 @@ import (
 	"github.com/rm-hull/dot-block/internal/metrics"
 )
 
+type DNSSource string
+
+const (
+	SourceUDP DNSSource = "UDP"
+	SourceTCP DNSSource = "TCP"
+	SourceDoT DNSSource = "DoT"
+)
+
+type RequestContext struct {
+	Logger    *slog.Logger
+	Source    DNSSource
+	StartTime *time.Time
+}
+
+type DispatcherFunc func(writer dns.ResponseWriter, req *dns.Msg)
+
 type DNSDispatcher struct {
 	dnsClient     *RoundRobinClient
 	defaultTTL    float64
@@ -57,86 +73,99 @@ func NewDNSDispatcher(
 	}, nil
 }
 
-func (d *DNSDispatcher) HandleDNSRequest(writer dns.ResponseWriter, req *dns.Msg) {
-	startTime := time.Now()
-	remoteAddr := writer.RemoteAddr().String()
-	ipAddr, _, err := net.SplitHostPort(remoteAddr)
-	if err != nil {
-		d.logger.Warn("failed to parse client IP from remote address", "remote_addr", remoteAddr, "error", err)
-		ipAddr = "unknown" // Fallback to "unknown" if IP parsing fails
-	}
-
-	requestLogger := d.logger.With("clientIP", ipAddr, "requestId", req.Id)
-
-	defer func() {
-		duration := time.Since(startTime).Seconds()
-		d.metrics.RequestLatency.Observe(duration)
-		d.metrics.RequestCounts.WithLabelValues("total").Inc()
-
-		loc, err := d.geoIpLookup.GetAll(ipAddr)
+func (d *DNSDispatcher) HandleDNSRequest(source DNSSource) DispatcherFunc {
+	return func(writer dns.ResponseWriter, req *dns.Msg) {
+		startTime := time.Now()
+		remoteAddr := writer.RemoteAddr().String()
+		ipAddr, _, err := net.SplitHostPort(remoteAddr)
 		if err != nil {
-			requestLogger.Warn("failed to get geolocation for client IP", "error", err)
-		} else {
-			d.metrics.CountryCounts.WithLabelValues(loc.Country_short).Inc()
-		}
-	}()
+			d.logger.Warn("failed to parse client IP from remote address",
+				"remote_addr", remoteAddr,
+				"source", source,
+				"error", err)
 
-	if err := d.updateClientCount(writer); err != nil {
-		requestLogger.Warn("failed to update client count", "error", err)
-	}
-
-	resp := new(dns.Msg)
-	resp.SetReply(req)
-	resp.Question = req.Question
-
-	unansweredQuestions := make([]dns.Question, 0, len(req.Question))
-
-	for _, q := range req.Question {
-		answers, err := d.processQuestion(requestLogger, &q)
-		if err != nil {
-			resp.Rcode = dns.RcodeServerFailure
-			d.sendResponse(requestLogger, writer, resp)
-			return
+			ipAddr = "unknown" // Fallback to "unknown" if IP parsing fails
 		}
 
-		if len(answers) > 0 {
+		ctx := &RequestContext{
+			Logger:    d.logger.With("clientIP", ipAddr, "requestId", req.Id, "source", source),
+			Source:    source,
+			StartTime: &startTime,
+		}
+
+		defer func() {
+			duration := time.Since(startTime).Seconds()
+			d.metrics.RequestLatency.Observe(duration)
+			d.metrics.RequestCounts.WithLabelValues("total", string(source)).Inc()
+
+			loc, err := d.geoIpLookup.GetAll(ipAddr)
+			if err != nil {
+				ctx.Logger.Warn("failed to get geolocation for client IP",
+					"error", err)
+			} else {
+				d.metrics.CountryCounts.WithLabelValues(loc.Country_short).Inc()
+			}
+		}()
+
+		if err := d.updateClientCount(writer); err != nil {
+			ctx.Logger.Warn("failed to update client count", "error", err)
+		}
+
+		resp := new(dns.Msg)
+		resp.SetReply(req)
+		resp.Question = req.Question
+
+		unansweredQuestions := make([]dns.Question, 0, len(req.Question))
+
+		for _, q := range req.Question {
+			answers, err := d.processQuestion(ctx, &q)
+			if err != nil {
+				resp.Rcode = dns.RcodeServerFailure
+				d.sendResponse(ctx, writer, resp)
+				return
+			}
+
+			if len(answers) > 0 {
+				resp.Answer = append(resp.Answer, answers...)
+			} else {
+				unansweredQuestions = append(unansweredQuestions, q)
+			}
+		}
+
+		if len(unansweredQuestions) > 0 {
+			rcode, answers, err := d.resolveUpstream(ctx, unansweredQuestions, req)
+			if err != nil {
+				resp.Rcode = rcode
+				d.reportError(ctx, "upstream", err, "qtype", getQueryType(&unansweredQuestions[0]))
+				d.sendResponse(ctx, writer, resp)
+				return
+			}
+
 			resp.Answer = append(resp.Answer, answers...)
-		} else {
-			unansweredQuestions = append(unansweredQuestions, q)
-		}
-	}
-
-	if len(unansweredQuestions) > 0 {
-		rcode, answers, err := d.resolveUpstream(unansweredQuestions, req)
-		if err != nil {
-			resp.Rcode = rcode
-			d.reportError(requestLogger, "upstream", err)
-			d.sendResponse(requestLogger, writer, resp)
-			return
 		}
 
-		resp.Answer = append(resp.Answer, answers...)
-	}
+		if len(resp.Answer) == 0 && len(resp.Ns) > 0 {
+			resp.Rcode = dns.RcodeNameError
+		}
 
-	if len(resp.Answer) == 0 && len(resp.Ns) > 0 {
-		resp.Rcode = dns.RcodeNameError
+		d.sendResponse(ctx, writer, resp)
 	}
-
-	d.sendResponse(requestLogger, writer, resp)
 }
 
-func (d *DNSDispatcher) processQuestion(requestLogger *slog.Logger, q *dns.Question) ([]dns.RR, error) {
+func (d *DNSDispatcher) processQuestion(ctx *RequestContext, q *dns.Question) ([]dns.RR, error) {
 	queryType := getQueryType(q)
-	requestLogger.Debug("Query received", "name", q.Name, "type", queryType)
+	ctx.Logger.Debug("Query received",
+		"name", q.Name,
+		"type", queryType)
 
 	isBlocked, err := d.blockList.IsBlocked(q.Name)
 	if err != nil {
-		d.reportError(requestLogger, "blocklist", err)
+		d.reportError(ctx, "blocklist", err, "qtype", queryType)
 		return nil, err
 	}
 
 	if isBlocked {
-		requestLogger.Debug("Domain blocked", "name", q.Name)
+		ctx.Logger.Debug("Domain blocked", "name", q.Name)
 		d.metrics.TopBlockedDomains.Add(q.Name)
 		d.metrics.QueryCounts.WithLabelValues(queryType, "true").Inc()
 
@@ -166,13 +195,13 @@ func (d *DNSDispatcher) processQuestion(requestLogger *slog.Logger, q *dns.Quest
 	return nil, nil
 }
 
-func (d *DNSDispatcher) resolveUpstream(unansweredQuestions []dns.Question, req *dns.Msg) (int, []dns.RR, error) {
+func (d *DNSDispatcher) resolveUpstream(ctx *RequestContext, unansweredQuestions []dns.Question, req *dns.Msg) (int, []dns.RR, error) {
 	upstreamReq := new(dns.Msg)
 	upstreamReq.Id = dns.Id()
 	upstreamReq.RecursionDesired = req.RecursionDesired
 	upstreamReq.Question = unansweredQuestions
 
-	upstreamResp, upstream, err := d.forwardQuery(upstreamReq)
+	upstreamResp, upstream, err := d.forwardQuery(ctx, upstreamReq)
 	if err != nil {
 		return dns.RcodeServerFailure, nil, err
 	}
@@ -242,16 +271,17 @@ func (d *DNSDispatcher) updateClientCount(writer dns.ResponseWriter) error {
 	return nil
 }
 
-func (d *DNSDispatcher) reportError(requestLogger *slog.Logger, errorCategory string, err error) {
-	requestLogger.Error("DNS error", "category", errorCategory, "error", err)
+func (d *DNSDispatcher) reportError(ctx *RequestContext, errorCategory string, err error, additionalFields ...any) {
+	args := append(additionalFields, "category", errorCategory, "error", err)
+	ctx.Logger.Error("DNS error", args...)
 	d.metrics.ErrorCounts.WithLabelValues(errorCategory).Inc()
-	d.metrics.RequestCounts.WithLabelValues("errored").Inc()
+	d.metrics.RequestCounts.WithLabelValues("errored", string(ctx.Source)).Inc()
 	sentry.CaptureException(err)
 }
 
-func (d *DNSDispatcher) forwardQuery(req *dns.Msg) (*dns.Msg, string, error) {
+func (d *DNSDispatcher) forwardQuery(ctx *RequestContext, req *dns.Msg) (*dns.Msg, string, error) {
 	startTime := time.Now()
-	d.metrics.RequestCounts.WithLabelValues("forwarded").Inc()
+	d.metrics.RequestCounts.WithLabelValues("forwarded", string(ctx.Source)).Inc()
 	in, upstream, err := d.dnsClient.Exchange(req)
 
 	duration := time.Since(startTime).Seconds()
@@ -259,10 +289,10 @@ func (d *DNSDispatcher) forwardQuery(req *dns.Msg) (*dns.Msg, string, error) {
 	return in, upstream, err
 }
 
-func (d *DNSDispatcher) sendResponse(requestLogger *slog.Logger, writer dns.ResponseWriter, msg *dns.Msg) {
+func (d *DNSDispatcher) sendResponse(ctx *RequestContext, writer dns.ResponseWriter, msg *dns.Msg) {
 	d.metrics.ReplyCounts.WithLabelValues(dns.RcodeToString[msg.Rcode]).Inc()
 	if err := writer.WriteMsg(msg); err != nil {
-		d.reportError(requestLogger, "response", err)
+		d.reportError(ctx, "response", err)
 		return
 	}
 }

--- a/internal/forwarder/dispatcher.go
+++ b/internal/forwarder/dispatcher.go
@@ -26,7 +26,7 @@ const (
 type RequestContext struct {
 	Logger    *slog.Logger
 	Source    DNSSource
-	StartTime *time.Time
+	StartTime time.Time
 }
 
 type DispatcherFunc func(writer dns.ResponseWriter, req *dns.Msg)
@@ -75,7 +75,6 @@ func NewDNSDispatcher(
 
 func (d *DNSDispatcher) HandleDNSRequest(source DNSSource) DispatcherFunc {
 	return func(writer dns.ResponseWriter, req *dns.Msg) {
-		startTime := time.Now()
 		remoteAddr := writer.RemoteAddr().String()
 		ipAddr, _, err := net.SplitHostPort(remoteAddr)
 		if err != nil {
@@ -85,31 +84,33 @@ func (d *DNSDispatcher) HandleDNSRequest(source DNSSource) DispatcherFunc {
 				"error", err)
 
 			ipAddr = "unknown" // Fallback to "unknown" if IP parsing fails
+		} else {
+			d.metrics.TopClients.Add(ipAddr)
+			d.metrics.UniqueClients.Insert([]byte(ipAddr))
 		}
 
 		ctx := &RequestContext{
 			Logger:    d.logger.With("clientIP", ipAddr, "requestId", req.Id, "source", source),
 			Source:    source,
-			StartTime: &startTime,
+			StartTime: time.Now(),
 		}
 
 		defer func() {
-			duration := time.Since(startTime).Seconds()
+			duration := time.Since(ctx.StartTime).Seconds()
 			d.metrics.RequestLatency.Observe(duration)
 			d.metrics.RequestCounts.WithLabelValues("total", string(source)).Inc()
 
+			if ipAddr == "unknown" {
+				return // Skip geolocation if IP is unknown
+			}
+
 			loc, err := d.geoIpLookup.GetAll(ipAddr)
 			if err != nil {
-				ctx.Logger.Warn("failed to get geolocation for client IP",
-					"error", err)
+				ctx.Logger.Warn("failed to get geolocation for client IP", "error", err)
 			} else {
 				d.metrics.CountryCounts.WithLabelValues(loc.Country_short).Inc()
 			}
 		}()
-
-		if err := d.updateClientCount(writer); err != nil {
-			ctx.Logger.Warn("failed to update client count", "error", err)
-		}
 
 		resp := new(dns.Msg)
 		resp.SetReply(req)
@@ -258,18 +259,6 @@ func (d *DNSDispatcher) isFreshnessSensitive(q *dns.Question) bool {
 }
 
 var freshnessSensitive = []string{"ocsp", "crl", "pki"}
-
-func (d *DNSDispatcher) updateClientCount(writer dns.ResponseWriter) error {
-	remoteAddr := writer.RemoteAddr().String()
-	host, _, err := net.SplitHostPort(remoteAddr)
-	if err != nil {
-		return errors.Wrapf(err, "failed to parse `host:port` from %s", remoteAddr)
-	}
-
-	d.metrics.TopClients.Add(host)
-	d.metrics.UniqueClients.Insert([]byte(host))
-	return nil
-}
 
 func (d *DNSDispatcher) reportError(ctx *RequestContext, errorCategory string, err error, additionalFields ...any) {
 	args := append(additionalFields, "category", errorCategory, "error", err)

--- a/internal/forwarder/dispatcher_test.go
+++ b/internal/forwarder/dispatcher_test.go
@@ -102,7 +102,7 @@ func TestDNSDispatcher_HandleDNSRequest_Allowed(t *testing.T) {
 	writer.On("WriteMsg", mock.Anything).Return(nil)
 
 	// Call the method under test
-	dispatcher.HandleDNSRequest(writer, req)
+	dispatcher.HandleDNSRequest("test")(writer, req)
 
 	// Assert that the response writer was called with a non-nil message
 	assert.NotNil(t, writer.WrittenMsg)
@@ -140,7 +140,7 @@ func TestDNSDispatcher_HandleDNSRequest_Blocked(t *testing.T) {
 	writer.On("WriteMsg", mock.Anything).Return(nil)
 
 	// Call the method under test
-	dispatcher.HandleDNSRequest(writer, req)
+	dispatcher.HandleDNSRequest("test")(writer, req)
 
 	// Assert that the response has an RcodeSuccess Rcode
 	assert.NotNil(t, writer.WrittenMsg)
@@ -182,7 +182,7 @@ func TestDNSDispatcher_HandleDNSRequest_MultipleQuestions(t *testing.T) {
 	writer.On("WriteMsg", mock.Anything).Return(nil)
 
 	// Call the method under test
-	dispatcher.HandleDNSRequest(writer, req)
+	dispatcher.HandleDNSRequest("test")(writer, req)
 
 	// Assert that the response writer was called with a non-nil message
 	assert.NotNil(t, writer.WrittenMsg)
@@ -230,7 +230,7 @@ func TestDNSDispatcher_HandleDNSRequest_CacheHit(t *testing.T) {
 	writer.On("WriteMsg", mock.Anything).Return(nil)
 
 	// First request: should be a cache miss and populate the cache
-	dispatcher.HandleDNSRequest(writer, req)
+	dispatcher.HandleDNSRequest("test")(writer, req)
 	assert.NotNil(t, writer.WrittenMsg)
 	assert.Equal(t, dns.RcodeSuccess, writer.WrittenMsg.Rcode)
 
@@ -244,7 +244,7 @@ func TestDNSDispatcher_HandleDNSRequest_CacheHit(t *testing.T) {
 	writer.On("WriteMsg", mock.Anything).Return(nil)
 
 	// Second request: should be a cache hit
-	dispatcher.HandleDNSRequest(writer, req)
+	dispatcher.HandleDNSRequest("test")(writer, req)
 	assert.NotNil(t, writer.WrittenMsg)
 	assert.Equal(t, dns.RcodeSuccess, writer.WrittenMsg.Rcode)
 
@@ -285,7 +285,7 @@ func TestDNSDispatcher_ResolveUpstream_BadRCode(t *testing.T) {
 	writer.On("WriteMsg", mock.Anything).Return(nil)
 
 	// Call the method under test
-	dispatcher.HandleDNSRequest(writer, req)
+	dispatcher.HandleDNSRequest("test")(writer, req)
 
 	assert.NotNil(t, writer.WrittenMsg)
 	assert.Equal(t, dns.RcodeRefused, writer.WrittenMsg.Rcode)
@@ -329,7 +329,7 @@ func TestDNSDispatcher_QueryLogging(t *testing.T) {
 		writer := new(MockResponseWriter)
 		writer.On("WriteMsg", mock.Anything).Return(nil)
 
-		dispatcher.HandleDNSRequest(writer, req)
+		dispatcher.HandleDNSRequest("test")(writer, req)
 
 		assert.NotContains(t, logBuf.String(), "Query received")
 	})
@@ -348,7 +348,7 @@ func TestDNSDispatcher_QueryLogging(t *testing.T) {
 		writer := new(MockResponseWriter)
 		writer.On("WriteMsg", mock.Anything).Return(nil)
 
-		dispatcher.HandleDNSRequest(writer, req)
+		dispatcher.HandleDNSRequest("test")(writer, req)
 
 		assert.Contains(t, logBuf.String(), "Query received")
 		assert.Contains(t, logBuf.String(), "google.com.")

--- a/internal/metrics/dns_metrics.go
+++ b/internal/metrics/dns_metrics.go
@@ -82,8 +82,8 @@ func NewDNSMetrics[K comparable, V any](cache cache.Cache[K, V]) (*DnsMetrics, e
 
 	requestCounts := prometheus.NewCounterVec(prometheus.CounterOpts{
 		Name: "dns_request_count",
-		Help: "Counts the number of DNS requests, broken down by type (total, errored, forwarded)",
-	}, []string{"type"})
+		Help: "Counts the number of DNS requests, broken down by type (total, errored, forwarded) and source (UDP, TCP, DoT)",
+	}, []string{"type", "source"})
 
 	queryCounts := prometheus.NewCounterVec(prometheus.CounterOpts{
 		Name: "dns_query_count",


### PR DESCRIPTION
Introduce `DNSSource` and `RequestContext` to differentiate between UDP, TCP, and DoT requests throughout the dispatching lifecycle.

- Update `DNSDispatcher` to accept the request source.
- Enhance `dns_request_count` metric with a `source` label.
- Consolidate logging context to include source and metadata.