### PR TITLE
refactor: implement asynchronous cache updates

### DIFF
--- a/internal/app.go
+++ b/internal/app.go
@@ -171,6 +171,8 @@ func (app *App) RunServer() error {
 	if err != nil {
 		return errors.Wrap(err, "failed to create dispatcher")
 	}
+	defer dispatcher.Close()
+
 	app.Logger.Info("Creating cache reaper cron job", "schedule", app.CronSchedule.CacheReaper)
 	if _, err = crontab.AddJob(app.CronSchedule.CacheReaper, forwarder.NewCacheReaperCronJob(dispatcher)); err != nil {
 		return errors.Wrap(err, "failed to create cache reaper cron job")

--- a/internal/forwarder/cache.go
+++ b/internal/forwarder/cache.go
@@ -17,9 +17,10 @@ type cacheUpdate struct {
 }
 
 type DNSCache struct {
-	cache      cache.Cache[string, []dns.RR]
-	updateChan chan cacheUpdate
-	logger     *slog.Logger
+	cache  cache.Cache[string, []dns.RR]
+	logger *slog.Logger
+	update chan cacheUpdate
+	done   chan struct{}
 }
 
 func NewDNSCache(maxSize int, logger *slog.Logger) *DNSCache {
@@ -27,9 +28,9 @@ func NewDNSCache(maxSize int, logger *slog.Logger) *DNSCache {
 	c := cache.NewCache[string, []dns.RR]().WithMaxKeys(maxSize).WithLRU()
 
 	dc := &DNSCache{
-		cache:      c,
-		updateChan: make(chan cacheUpdate, CACHE_UPDATE_BUFFER_SIZE),
-		logger:     logger,
+		cache:  c,
+		update: make(chan cacheUpdate, CACHE_UPDATE_BUFFER_SIZE),
+		logger: logger,
 	}
 
 	go dc.runUpdateWorker()
@@ -39,9 +40,21 @@ func NewDNSCache(maxSize int, logger *slog.Logger) *DNSCache {
 }
 
 func (dc *DNSCache) runUpdateWorker() {
-	for update := range dc.updateChan {
-		dc.cache.Set(update.key, update.values, update.ttl)
+	for {
+		select {
+		case update, ok := <-dc.update:
+			if !ok {
+				return
+			}
+			dc.cache.Set(update.key, update.values, update.ttl)
+		case <-dc.done:
+			return
+		}
 	}
+}
+
+func (dc *DNSCache) Close() {
+	close(dc.done)
 }
 
 //go:inline
@@ -52,7 +65,9 @@ func (dc *DNSCache) Get(key string) ([]dns.RR, bool) {
 //go:inline
 func (dc *DNSCache) Set(key string, values []dns.RR, ttl time.Duration) {
 	select {
-	case dc.updateChan <- cacheUpdate{key: key, values: values, ttl: ttl}:
+	case <-dc.done:
+		return
+	case dc.update <- cacheUpdate{key: key, values: values, ttl: ttl}:
 	default:
 		dc.logger.Warn("DNS cache update channel full, dropping update", "key", key)
 	}

--- a/internal/forwarder/cache.go
+++ b/internal/forwarder/cache.go
@@ -65,7 +65,15 @@ func (dc *DNSCache) OnDrop(fn func()) {
 }
 
 func (dc *DNSCache) Get(key string) ([]dns.RR, bool) {
-	return dc.cache.Get(key)
+	rrs, ok := dc.cache.Get(key)
+	if !ok {
+		return nil, false
+	}
+	copied := make([]dns.RR, len(rrs))
+	for i, rr := range rrs {
+		copied[i] = dns.Copy(rr)
+	}
+	return copied, true
 }
 
 func (dc *DNSCache) Set(key string, values []dns.RR, ttl time.Duration) {

--- a/internal/forwarder/cache.go
+++ b/internal/forwarder/cache.go
@@ -24,13 +24,14 @@ type DNSCache struct {
 }
 
 func NewDNSCache(maxSize int, logger *slog.Logger) *DNSCache {
-	logger.Info("Initializing DNS cache", "maxCcheSize", maxSize, "updateBufferSize", CACHE_UPDATE_BUFFER_SIZE)
+	logger.Info("Initializing DNS cache", "maxCacheSize", maxSize, "updateBufferSize", CACHE_UPDATE_BUFFER_SIZE)
 	c := cache.NewCache[string, []dns.RR]().WithMaxKeys(maxSize).WithLRU()
 
 	dc := &DNSCache{
 		cache:  c,
-		update: make(chan cacheUpdate, CACHE_UPDATE_BUFFER_SIZE),
 		logger: logger,
+		update: make(chan cacheUpdate, CACHE_UPDATE_BUFFER_SIZE),
+		done:   make(chan struct{}),
 	}
 
 	go dc.runUpdateWorker()

--- a/internal/forwarder/cache.go
+++ b/internal/forwarder/cache.go
@@ -17,10 +17,12 @@ type cacheUpdate struct {
 }
 
 type DNSCache struct {
-	cache  cache.Cache[string, []dns.RR]
-	logger *slog.Logger
-	update chan cacheUpdate
-	done   chan struct{}
+	cache    cache.Cache[string, []dns.RR]
+	logger   *slog.Logger
+	update   chan cacheUpdate
+	done     chan struct{}
+	onDrop   func()
+	lastWarn time.Time
 }
 
 func NewDNSCache(maxSize int, logger *slog.Logger) *DNSCache {
@@ -58,6 +60,10 @@ func (dc *DNSCache) Close() {
 	close(dc.done)
 }
 
+func (dc *DNSCache) OnDrop(fn func()) {
+	dc.onDrop = fn
+}
+
 func (dc *DNSCache) Get(key string) ([]dns.RR, bool) {
 	return dc.cache.Get(key)
 }
@@ -68,7 +74,14 @@ func (dc *DNSCache) Set(key string, values []dns.RR, ttl time.Duration) {
 		return
 	case dc.update <- cacheUpdate{key: key, values: values, ttl: ttl}:
 	default:
-		dc.logger.Warn("DNS cache update channel full, dropping update", "key", key)
+		if dc.onDrop != nil {
+			dc.onDrop()
+		}
+
+		if time.Since(dc.lastWarn) > 1*time.Minute {
+			dc.logger.Warn("DNS cache update channel full, dropping update", "key", key)
+			dc.lastWarn = time.Now()
+		}
 	}
 }
 

--- a/internal/forwarder/cache.go
+++ b/internal/forwarder/cache.go
@@ -1,0 +1,71 @@
+package forwarder
+
+import (
+	"log/slog"
+	"time"
+
+	cache "github.com/go-pkgz/expirable-cache/v3"
+	"github.com/miekg/dns"
+)
+
+const CACHE_UPDATE_BUFFER_SIZE = 10_000
+
+type cacheUpdate struct {
+	key    string
+	values []dns.RR
+	ttl    time.Duration
+}
+
+type DNSCache struct {
+	cache      cache.Cache[string, []dns.RR]
+	updateChan chan cacheUpdate
+	logger     *slog.Logger
+}
+
+func NewDNSCache(maxSize int, logger *slog.Logger) *DNSCache {
+	logger.Info("Initializing DNS cache", "maxCcheSize", maxSize, "updateBufferSize", CACHE_UPDATE_BUFFER_SIZE)
+	c := cache.NewCache[string, []dns.RR]().WithMaxKeys(maxSize).WithLRU()
+
+	dc := &DNSCache{
+		cache:      c,
+		updateChan: make(chan cacheUpdate, CACHE_UPDATE_BUFFER_SIZE),
+		logger:     logger,
+	}
+
+	go dc.runUpdateWorker()
+
+	return dc
+}
+
+func (dc *DNSCache) runUpdateWorker() {
+	dc.logger.Info("Starting DNS cache update worker...")
+	for update := range dc.updateChan {
+		dc.cache.Set(update.key, update.values, update.ttl)
+	}
+}
+
+//go:inline
+func (dc *DNSCache) Get(key string) ([]dns.RR, bool) {
+	return dc.cache.Get(key)
+}
+
+//go:inline
+func (dc *DNSCache) Set(key string, values []dns.RR, ttl time.Duration) {
+	select {
+	case dc.updateChan <- cacheUpdate{key: key, values: values, ttl: ttl}:
+	default:
+		dc.logger.Warn("DNS cache update channel full, dropping update", "key", key)
+	}
+}
+
+func (dc *DNSCache) DeleteExpired() {
+	dc.cache.DeleteExpired()
+}
+
+func (dc *DNSCache) Len() int {
+	return dc.cache.Len()
+}
+
+func (dc *DNSCache) Stat() cache.Stats {
+	return dc.cache.Stat()
+}

--- a/internal/forwarder/cache.go
+++ b/internal/forwarder/cache.go
@@ -33,12 +33,12 @@ func NewDNSCache(maxSize int, logger *slog.Logger) *DNSCache {
 	}
 
 	go dc.runUpdateWorker()
+	logger.Info("Started DNS cache update worker...")
 
 	return dc
 }
 
 func (dc *DNSCache) runUpdateWorker() {
-	dc.logger.Info("Starting DNS cache update worker...")
 	for update := range dc.updateChan {
 		dc.cache.Set(update.key, update.values, update.ttl)
 	}

--- a/internal/forwarder/cache.go
+++ b/internal/forwarder/cache.go
@@ -57,12 +57,10 @@ func (dc *DNSCache) Close() {
 	close(dc.done)
 }
 
-//go:inline
 func (dc *DNSCache) Get(key string) ([]dns.RR, bool) {
 	return dc.cache.Get(key)
 }
 
-//go:inline
 func (dc *DNSCache) Set(key string, values []dns.RR, ttl time.Duration) {
 	select {
 	case <-dc.done:

--- a/internal/forwarder/cache_reaper.go
+++ b/internal/forwarder/cache_reaper.go
@@ -1,25 +1,30 @@
 package forwarder
 
-import "github.com/robfig/cron/v3"
+import (
+	"log/slog"
+
+	"github.com/rm-hull/dot-block/internal/metrics"
+	"github.com/robfig/cron/v3"
+)
 
 type CacheReaper struct {
-	dispatcher *DNSDispatcher
+	cache   DNSCache
+	logger  *slog.Logger
+	metrics *metrics.DnsMetrics
 }
 
 func NewCacheReaperCronJob(dispatcher *DNSDispatcher) cron.Job {
-	return &CacheReaper{
-		dispatcher: dispatcher,
-	}
+	return &CacheReaper{cache: *dispatcher.cache, logger: dispatcher.logger, metrics: dispatcher.metrics}
 }
 
 func (job *CacheReaper) Run() {
-	sizeBefore := job.dispatcher.cache.Len()
-	job.dispatcher.cache.DeleteExpired()
+	sizeBefore := job.cache.Len()
+	job.cache.DeleteExpired()
 
-	sizeAfter := job.dispatcher.cache.Len()
-	job.dispatcher.logger.Debug("Cleaned up expired DNS cache entries",
+	sizeAfter := job.cache.Len()
+	job.logger.Info("Cleaned up expired DNS cache entries",
 		"size", sizeAfter,
 		"removed", sizeBefore-sizeAfter)
 
-	job.dispatcher.metrics.CacheReaperCalls.Inc()
+	job.metrics.CacheReaperCalls.Inc()
 }

--- a/internal/forwarder/cache_reaper.go
+++ b/internal/forwarder/cache_reaper.go
@@ -8,13 +8,13 @@ import (
 )
 
 type CacheReaper struct {
-	cache   DNSCache
+	cache   *DNSCache
 	logger  *slog.Logger
 	metrics *metrics.DnsMetrics
 }
 
 func NewCacheReaperCronJob(dispatcher *DNSDispatcher) cron.Job {
-	return &CacheReaper{cache: *dispatcher.cache, logger: dispatcher.logger, metrics: dispatcher.metrics}
+	return &CacheReaper{cache: dispatcher.cache, logger: dispatcher.logger, metrics: dispatcher.metrics}
 }
 
 func (job *CacheReaper) Run() {

--- a/internal/forwarder/dispatcher.go
+++ b/internal/forwarder/dispatcher.go
@@ -248,7 +248,6 @@ func (d *DNSDispatcher) resolveUpstream(ctx *RequestContext, unansweredQuestions
 	return upstreamReq.Rcode, upstreamResp.Answer, nil
 }
 
-//go:inline
 func (d *DNSDispatcher) isFreshnessSensitive(q *dns.Question) bool {
 	// Check query type
 	switch q.Qtype {
@@ -294,12 +293,10 @@ func (d *DNSDispatcher) sendResponse(ctx *RequestContext, writer dns.ResponseWri
 	}
 }
 
-//go:inline
 func getCacheKey(q *dns.Question) string {
 	return dns.Fqdn(q.Name) + ":" + getQueryType(q)
 }
 
-//go:inline
 func getQueryType(q *dns.Question) string {
 	return dns.TypeToString[q.Qtype]
 }

--- a/internal/forwarder/dispatcher.go
+++ b/internal/forwarder/dispatcher.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/cockroachdb/errors"
 	"github.com/getsentry/sentry-go"
-	cache "github.com/go-pkgz/expirable-cache/v3"
 	"github.com/miekg/dns"
 	"github.com/rm-hull/dot-block/internal/blocklist"
 	"github.com/rm-hull/dot-block/internal/geoblock"
@@ -33,14 +32,14 @@ type RequestContext struct {
 type DispatcherFunc func(writer dns.ResponseWriter, req *dns.Msg)
 
 type DNSDispatcher struct {
-	dnsClient     *RoundRobinClient
-	defaultTTL    float64
-	cacheTtlFloor time.Duration
-	cache         cache.Cache[string, []dns.RR]
-	blockList     *blocklist.BlockList
-	geoIpLookup   geoblock.GeoIpLookup
-	metrics       *metrics.DnsMetrics
-	logger        *slog.Logger
+	dnsClient   *RoundRobinClient
+	defaultTTL  float64
+	ttlFloor    time.Duration
+	cache       *DNSCache
+	blockList   *blocklist.BlockList
+	geoIpLookup geoblock.GeoIpLookup
+	metrics     *metrics.DnsMetrics
+	logger      *slog.Logger
 }
 
 func NewDNSDispatcher(
@@ -48,29 +47,30 @@ func NewDNSDispatcher(
 	blockList *blocklist.BlockList,
 	geoIpLookup geoblock.GeoIpLookup,
 	maxSize int,
-	cacheTtlFloor time.Duration,
+	ttlFloor time.Duration,
 	logger *slog.Logger,
 ) (*DNSDispatcher, error) {
 
-	if cacheTtlFloor < 0 {
-		return nil, errors.New("cacheTtlFloor cannot be negative")
+	if ttlFloor < 0 {
+		return nil, errors.New("TTL floor cannot be negative")
 	}
 
-	cache := cache.NewCache[string, []dns.RR]().WithMaxKeys(maxSize).WithLRU()
+	cache := NewDNSCache(maxSize, logger)
+
 	metrics, err := metrics.NewDNSMetrics(cache)
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to initialize")
+		return nil, errors.Wrap(err, "failed to initialize metrics")
 	}
 
 	return &DNSDispatcher{
-		dnsClient:     dnsClient,
-		defaultTTL:    300, // TODO: pass in
-		cacheTtlFloor: cacheTtlFloor,
-		cache:         cache,
-		blockList:     blockList,
-		geoIpLookup:   geoIpLookup,
-		metrics:       metrics,
-		logger:        logger,
+		dnsClient:   dnsClient,
+		defaultTTL:  300, // TODO: pass in
+		ttlFloor:    ttlFloor,
+		cache:       cache,
+		blockList:   blockList,
+		geoIpLookup: geoIpLookup,
+		metrics:     metrics,
+		logger:      logger,
 	}, nil
 }
 
@@ -233,8 +233,8 @@ func (d *DNSDispatcher) resolveUpstream(ctx *RequestContext, unansweredQuestions
 			upstreamTTL := answersForQuestion[0].Header().Ttl
 			effectiveTTL := time.Duration(upstreamTTL) * time.Second
 
-			if !d.isFreshnessSensitive(&q) && effectiveTTL < d.cacheTtlFloor {
-				effectiveTTL = d.cacheTtlFloor
+			if !d.isFreshnessSensitive(&q) && effectiveTTL < d.ttlFloor {
+				effectiveTTL = d.ttlFloor
 			}
 
 			d.cache.Set(key, answersForQuestion, effectiveTTL)

--- a/internal/forwarder/dispatcher.go
+++ b/internal/forwarder/dispatcher.go
@@ -56,7 +56,6 @@ func NewDNSDispatcher(
 	}
 
 	cache := NewDNSCache(maxSize, logger)
-
 	metrics, err := metrics.NewDNSMetrics(cache)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to initialize metrics")
@@ -72,6 +71,10 @@ func NewDNSDispatcher(
 		metrics:     metrics,
 		logger:      logger,
 	}, nil
+}
+
+func (d *DNSDispatcher) Close() {
+	d.cache.Close()
 }
 
 func (d *DNSDispatcher) HandleDNSRequest(source DNSSource) DispatcherFunc {

--- a/internal/forwarder/dispatcher_test.go
+++ b/internal/forwarder/dispatcher_test.go
@@ -94,6 +94,7 @@ func TestDNSDispatcher_HandleDNSRequest_Allowed(t *testing.T) {
 
 	dispatcher, err := NewDNSDispatcher(dnsClient, blockList, mockGeo, 100, 1*time.Minute, logger)
 	assert.NoError(t, err)
+	t.Cleanup(dispatcher.Close)
 
 	req := new(dns.Msg)
 	req.SetQuestion("google.com.", dns.TypeA)
@@ -132,6 +133,7 @@ func TestDNSDispatcher_HandleDNSRequest_Blocked(t *testing.T) {
 
 	dispatcher, err := NewDNSDispatcher(dnsClient, blockList, mockGeo, 100, 1*time.Minute, logger)
 	assert.NoError(t, err)
+	t.Cleanup(dispatcher.Close)
 
 	req := new(dns.Msg)
 	req.SetQuestion("ads.0xbt.net.", dns.TypeA)
@@ -171,6 +173,7 @@ func TestDNSDispatcher_HandleDNSRequest_MultipleQuestions(t *testing.T) {
 
 	dispatcher, err := NewDNSDispatcher(dnsClient, blockList, mockGeo, 100, 1*time.Minute, logger)
 	assert.NoError(t, err)
+	t.Cleanup(dispatcher.Close)
 
 	req := new(dns.Msg)
 	req.Question = []dns.Question{
@@ -222,6 +225,7 @@ func TestDNSDispatcher_HandleDNSRequest_CacheHit(t *testing.T) {
 
 	dispatcher, err := NewDNSDispatcher(dnsClient, blockList, mockGeo, 100, 1*time.Minute, logger)
 	assert.NoError(t, err)
+	t.Cleanup(dispatcher.Close)
 
 	req := new(dns.Msg)
 	req.SetQuestion("example.com.", dns.TypeA)
@@ -286,6 +290,7 @@ func TestDNSDispatcher_ResolveUpstream_BadRCode(t *testing.T) {
 
 	dispatcher, err := NewDNSDispatcher(dnsClient, blockList, mockGeo, 100, 1*time.Minute, logger)
 	require.NoError(t, err)
+	t.Cleanup(dispatcher.Close)
 
 	req := new(dns.Msg)
 	req.SetQuestion("google.com.", dns.TypeA)
@@ -332,6 +337,7 @@ func TestDNSDispatcher_QueryLogging(t *testing.T) {
 
 		dispatcher, err := NewDNSDispatcher(dnsClient, blockList, mockGeo, 100, 1*time.Minute, logger)
 		require.NoError(t, err)
+		t.Cleanup(dispatcher.Close)
 
 		req := new(dns.Msg)
 		req.SetQuestion("google.com.", dns.TypeA)
@@ -351,6 +357,7 @@ func TestDNSDispatcher_QueryLogging(t *testing.T) {
 
 		dispatcher, err := NewDNSDispatcher(dnsClient, blockList, mockGeo, 100, 1*time.Minute, logger)
 		require.NoError(t, err)
+		t.Cleanup(dispatcher.Close)
 
 		req := new(dns.Msg)
 		req.SetQuestion("google.com.", dns.TypeA)

--- a/internal/forwarder/dispatcher_test.go
+++ b/internal/forwarder/dispatcher_test.go
@@ -254,6 +254,13 @@ func TestDNSDispatcher_HandleDNSRequest_CacheHit(t *testing.T) {
 		stats := dispatcher.cache.Stat()
 		return stats.Hits == 1 && stats.Misses == 1
 	}, 2*time.Second, 10*time.Millisecond, "Expected 1 cache hit and 1 miss")
+
+	// Ensure the cache item is actually retrievable before asserting stats
+	cacheKey := getCacheKey(&req.Question[0])
+	assert.Eventually(t, func() bool {
+		_, ok := dispatcher.cache.Get(cacheKey)
+		return ok // Wait until Get actually finds the item
+	}, 2*time.Second, 10*time.Millisecond, "Cache item not found after first request before second query")
 }
 
 func TestDNSDispatcher_ResolveUpstream_BadRCode(t *testing.T) {

--- a/internal/forwarder/dispatcher_test.go
+++ b/internal/forwarder/dispatcher_test.go
@@ -234,10 +234,11 @@ func TestDNSDispatcher_HandleDNSRequest_CacheHit(t *testing.T) {
 	assert.NotNil(t, writer.WrittenMsg)
 	assert.Equal(t, dns.RcodeSuccess, writer.WrittenMsg.Rcode)
 
-	// Assert cache stats
-	stats := dispatcher.cache.Stat()
-	assert.Equal(t, 0, stats.Hits, "Expected 0 cache hit")
-	assert.Equal(t, 1, stats.Misses, "Expected 1 cache miss")
+	// Poll for cache miss to be recorded
+	assert.Eventually(t, func() bool {
+		stats := dispatcher.cache.Stat()
+		return stats.Misses == 1 && stats.Hits == 0
+	}, 2*time.Second, 10*time.Millisecond, "Expected 1 cache miss and 0 hits")
 
 	// Reset mock for the second request
 	writer = new(MockResponseWriter)
@@ -248,10 +249,11 @@ func TestDNSDispatcher_HandleDNSRequest_CacheHit(t *testing.T) {
 	assert.NotNil(t, writer.WrittenMsg)
 	assert.Equal(t, dns.RcodeSuccess, writer.WrittenMsg.Rcode)
 
-	// Assert cache stats
-	stats = dispatcher.cache.Stat()
-	assert.Equal(t, 1, stats.Hits, "Expected 1 cache hit")
-	assert.Equal(t, 1, stats.Misses, "Expected 1 cache miss")
+	// Poll for cache hit to be recorded
+	assert.Eventually(t, func() bool {
+		stats := dispatcher.cache.Stat()
+		return stats.Hits == 1 && stats.Misses == 1
+	}, 2*time.Second, 10*time.Millisecond, "Expected 1 cache hit and 1 miss")
 }
 
 func TestDNSDispatcher_ResolveUpstream_BadRCode(t *testing.T) {

--- a/internal/forwarder/dispatcher_test.go
+++ b/internal/forwarder/dispatcher_test.go
@@ -300,7 +300,7 @@ func TestNewDNSDispatcher_NegativeCacheTtlFloor(t *testing.T) {
 	dispatcher, err := NewDNSDispatcher(dnsClient, blockList, mockGeo, 100, -1*time.Second, logger)
 	assert.Error(t, err)
 	assert.Nil(t, dispatcher)
-	assert.Contains(t, err.Error(), "cacheTtlFloor cannot be negative")
+	assert.Contains(t, err.Error(), "TTL floor cannot be negative")
 }
 
 func TestDNSDispatcher_QueryLogging(t *testing.T) {

--- a/internal/metrics/dns_metrics.go
+++ b/internal/metrics/dns_metrics.go
@@ -14,19 +14,20 @@ import (
 const TOP_K = 50
 
 type DnsMetrics struct {
-	RequestLatency    prometheus.Histogram
-	ErrorCounts       *prometheus.CounterVec
-	RequestCounts     *prometheus.CounterVec
-	QueryCounts       *prometheus.CounterVec
-	ReplyCounts       *prometheus.CounterVec
-	CountryCounts     *prometheus.CounterVec
-	UniqueClients     *hyperloglog.Sketch
-	TopClients        *SpaceSaver
-	TopDomains        *SpaceSaver
-	TopBlockedDomains *SpaceSaver
-	UpstreamTTLs      *prometheus.HistogramVec
-	UpstreamLatency   *prometheus.HistogramVec
-	CacheReaperCalls  prometheus.Counter
+	RequestLatency      prometheus.Histogram
+	ErrorCounts         *prometheus.CounterVec
+	RequestCounts       *prometheus.CounterVec
+	QueryCounts         *prometheus.CounterVec
+	ReplyCounts         *prometheus.CounterVec
+	CountryCounts       *prometheus.CounterVec
+	UniqueClients       *hyperloglog.Sketch
+	TopClients          *SpaceSaver
+	TopDomains          *SpaceSaver
+	TopBlockedDomains   *SpaceSaver
+	UpstreamTTLs        *prometheus.HistogramVec
+	UpstreamLatency     *prometheus.HistogramVec
+	CacheReaperCalls    prometheus.Counter
+	DroppedCacheUpdates prometheus.Counter
 }
 
 var latencyBuckets = []float64{
@@ -37,6 +38,7 @@ var latencyBuckets = []float64{
 type Cache interface {
 	Stat() cache.Stats
 	Len() int
+	OnDrop(func())
 }
 
 func NewDNSMetrics(cache Cache) (*DnsMetrics, error) {
@@ -133,6 +135,11 @@ func NewDNSMetrics(cache Cache) (*DnsMetrics, error) {
 		Help: "The number of times the cache reaper has been called",
 	})
 
+	droppedCacheUpdates := prometheus.NewCounter(prometheus.CounterOpts{
+		Name: "dns_cache_dropped_updates_total",
+		Help: "Total number of cache updates dropped because the update channel was full",
+	})
+
 	if err := shouldRegister(
 		requestLatency,
 		errorCounts,
@@ -148,24 +155,28 @@ func NewDNSMetrics(cache Cache) (*DnsMetrics, error) {
 		upstreamTTLs,
 		upstreamLatency,
 		cacheReaperCalls,
+		droppedCacheUpdates,
 	); err != nil {
 		return nil, errors.Wrap(err, "failed to register DNS metrics")
 	}
 
+	cache.OnDrop(func() { droppedCacheUpdates.Inc() })
+
 	return &DnsMetrics{
-		RequestLatency:    requestLatency,
-		ErrorCounts:       errorCounts,
-		RequestCounts:     requestCounts,
-		QueryCounts:       queryCounts,
-		ReplyCounts:       replyCounts,
-		CountryCounts:     countryCounts,
-		UniqueClients:     uniqueClients,
-		TopClients:        topClients,
-		TopDomains:        topDomains,
-		TopBlockedDomains: topBlockedDomains,
-		UpstreamTTLs:      upstreamTTLs,
-		UpstreamLatency:   upstreamLatency,
-		CacheReaperCalls:  cacheReaperCalls,
+		RequestLatency:      requestLatency,
+		ErrorCounts:         errorCounts,
+		RequestCounts:       requestCounts,
+		QueryCounts:         queryCounts,
+		ReplyCounts:         replyCounts,
+		CountryCounts:       countryCounts,
+		UniqueClients:       uniqueClients,
+		TopClients:          topClients,
+		TopDomains:          topDomains,
+		TopBlockedDomains:   topBlockedDomains,
+		UpstreamTTLs:        upstreamTTLs,
+		UpstreamLatency:     upstreamLatency,
+		CacheReaperCalls:    cacheReaperCalls,
+		DroppedCacheUpdates: droppedCacheUpdates,
 	}, nil
 }
 

--- a/internal/metrics/dns_metrics.go
+++ b/internal/metrics/dns_metrics.go
@@ -34,7 +34,12 @@ var latencyBuckets = []float64{
 	0.05, 0.1, 0.25, 0.5, 1.0, 2.5, 5.0, math.Inf(1),
 }
 
-func NewDNSMetrics[K comparable, V any](cache cache.Cache[K, V]) (*DnsMetrics, error) {
+type Cache interface {
+	Stat() cache.Stats
+	Len() int
+}
+
+func NewDNSMetrics(cache Cache) (*DnsMetrics, error) {
 	uniqueClients := hyperloglog.New14()
 	topClients := NewSpaceSaver(TOP_K)
 	topDomains := NewSpaceSaver(TOP_K)

--- a/main.go
+++ b/main.go
@@ -13,7 +13,7 @@ import (
 
 const DEFAULT_DOWNLOADER_CRON_SCHEDULE = "@every 19h"
 const DEFAULT_CACHE_REAPER_CRON_SCHEDULE = "0 3 * * *" // 3:00am every day
-const DEFAULT_IP2LOCATION_CRON_SCHEDULE = "5 7 4 * *" // 7:05am on the 4th of every month
+const DEFAULT_IP2LOCATION_CRON_SCHEDULE = "5 7 4 * *"  // 7:05am on the 4th of every month
 
 var DEFAULT_BLOCKLIST_URLS = []string{
 	"https://codeberg.org/hagezi/mirror2/raw/branch/main/dns-blocklists/hosts/pro.txt",       // Hagezi Pro blocklist


### PR DESCRIPTION
Introduced `DNSCache` with an update worker pattern to offload cache writes to a background channel, reducing latency for primary request processing paths. Decoupled metrics from the concrete cache type using an interface.