### PR TITLE
feat: add configurable upstream connection timeout

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,10 +122,11 @@ DoT Block can be configured using the following command-line flags:
 
 | Flag | Description | Default |
 | :--- | :--- | :--- |
-| `--cache-ttl-floor` | Minimum TTL for cached entries (in seconds). If a response is not "freshness sensitive" (e.g. contains `ocsp`, `crl`, `pki` or is `SOA`/`TXT`), the cache TTL will be at least this value. | `3600` |
 | `--allowed-host` | List of domains used for the CertManager allow policy. | `nil` |
 | `--blocklist-url` | List of URL blocklists (wildcard hostname format). | `https://codeberg.org/hagezi/mirror2/raw/branch/main/dns-blocklists/hosts/pro.txt`, `https://raw.githubusercontent.com/rm-hull/dot-block/refs/heads/main/data/blocklist.txt"` |
-| `--cron-schedule:cache-reaper` | Cron spec for cache reaper. | `@every 10m` |
+| `--cache-ttl-floor` | Minimum TTL for cached entries (in seconds). If a response is not "freshness sensitive" (e.g. contains `ocsp`, `crl`, `pki` or is `SOA`/`TXT`), the cache TTL will be at least this value. | `3600s` |
+| `--connection-timeout` | Timeout for upstream DNS | `500ms` |
+| `--cron-schedule:cache-reaper` | Cron spec for cache reaper. | `0 3 * * *` (3:00am every day) |
 | `--cron-schedule:downloader` | Cron spec for reloading blocklist. | `@every 19h` |
 | `--cron-schedule:ip2location` | Cron spec for fetching IP2Location db. | `5 7 4 * *` (7:05am on the 4th of every month) |
 | `--data-dir` | Directory for persisting data (e.g. TLS certificate cache). | `./data` |

--- a/internal/app.go
+++ b/internal/app.go
@@ -56,6 +56,7 @@ type App struct {
 		IP2Location string `json:"ip2location"`
 	} `json:"cron_schedule"`
 	CacheTtlFloor        time.Duration `json:"cache_ttl_floor"`
+	ConnectionTimeout    time.Duration `json:"connection_timeout"`
 	RequireProxyProtocol bool          `json:"require_proxy_protocol"`
 	TrustedProxies       []string      `json:"trusted_proxies,omitempty"`
 }
@@ -156,8 +157,7 @@ func (app *App) RunServer() error {
 		}
 	}
 
-	timeout := 3 * time.Second
-	dnsClient, err := forwarder.NewRoundRobinClient(timeout, app.Upstreams...)
+	dnsClient, err := forwarder.NewRoundRobinClient(app.ConnectionTimeout, app.Upstreams...)
 	if err != nil {
 		return errors.Wrap(err, "failed to initialize upstream DNS client")
 	}

--- a/internal/forwarder/round_robin_client.go
+++ b/internal/forwarder/round_robin_client.go
@@ -27,8 +27,8 @@ func NewRoundRobinClient(timeout time.Duration, upstreams ...string) (*RoundRobi
 }
 
 func (r *RoundRobinClient) Exchange(msg *dns.Msg) (*dns.Msg, string, error) {
-	n := len(r.upstreams)
-	start := int(atomic.AddUint32(&r.counter, 1) - 1)
+	n := uint32(len(r.upstreams))
+	start := uint32(atomic.AddUint32(&r.counter, 1) - 1)
 
 	var lastErr error
 	for i := range n {

--- a/internal/forwarder/round_robin_client.go
+++ b/internal/forwarder/round_robin_client.go
@@ -1,7 +1,6 @@
 package forwarder
 
 import (
-	"net"
 	"sync/atomic"
 	"time"
 
@@ -37,20 +36,9 @@ func (r *RoundRobinClient) Exchange(msg *dns.Msg) (*dns.Msg, string, error) {
 		if err == nil {
 			return resp, upstream, nil
 		}
-
-		// Only fall through to next upstream on network/timeout errors, not DNS errors
-		if isTimeoutError(err) {
-			lastErr = errors.Wrapf(err, "timeout from upstream %s", upstream)
-			continue
-		}
-		return nil, "", errors.Wrapf(err, "DNS error from upstream %s", upstream)
+		lastErr = errors.Wrapf(err, "upstream %s failed", upstream)
 	}
 	return nil, "", errors.Wrap(lastErr, "all upstream servers failed")
-}
-
-func isTimeoutError(err error) bool {
-	var netErr net.Error
-	return errors.As(err, &netErr) && netErr.Timeout()
 }
 
 func (r *RoundRobinClient) Healthchecks() []checks.Check {

--- a/internal/forwarder/round_robin_client.go
+++ b/internal/forwarder/round_robin_client.go
@@ -1,6 +1,7 @@
 package forwarder
 
 import (
+	"net"
 	"sync/atomic"
 	"time"
 
@@ -25,15 +26,31 @@ func NewRoundRobinClient(timeout time.Duration, upstreams ...string) (*RoundRobi
 	}, nil
 }
 
-func (r *RoundRobinClient) getNextUpstream() string {
-	n := atomic.AddUint32(&r.counter, 1)
-	return r.upstreams[(int(n)-1)%len(r.upstreams)]
+func (r *RoundRobinClient) Exchange(msg *dns.Msg) (*dns.Msg, string, error) {
+	n := len(r.upstreams)
+	start := int(atomic.AddUint32(&r.counter, 1) - 1)
+
+	var lastErr error
+	for i := range n {
+		upstream := r.upstreams[(start+i)%n]
+		resp, _, err := r.client.Exchange(msg, upstream)
+		if err == nil {
+			return resp, upstream, nil
+		}
+
+		// Only fall through to next upstream on network/timeout errors, not DNS errors
+		if isTimeoutError(err) {
+			lastErr = errors.Wrapf(err, "timeout from upstream %s", upstream)
+			continue
+		}
+		return nil, "", errors.Wrapf(err, "DNS error from upstream %s", upstream)
+	}
+	return nil, "", errors.Wrap(lastErr, "all upstream servers failed")
 }
 
-func (r *RoundRobinClient) Exchange(msg *dns.Msg) (*dns.Msg, string, error) {
-	upstream := r.getNextUpstream()
-	resp, _, err := r.client.Exchange(msg, upstream)
-	return resp, upstream, err
+func isTimeoutError(err error) bool {
+	var netErr net.Error
+	return errors.As(err, &netErr) && netErr.Timeout()
 }
 
 func (r *RoundRobinClient) Healthchecks() []checks.Check {

--- a/main.go
+++ b/main.go
@@ -93,6 +93,7 @@ func main() {
 	rootCmd.Flags().StringVar(&app.CronSchedule.CacheReaper, "cron-schedule:cache-reaper", DEFAULT_CACHE_REAPER_CRON_SCHEDULE, "cron spec for cache reaper")
 	rootCmd.Flags().StringVar(&app.CronSchedule.IP2Location, "cron-schedule:ip2location", DEFAULT_IP2LOCATION_CRON_SCHEDULE, "cron spec for Ip2location downloader")
 	rootCmd.Flags().DurationVar(&app.CacheTtlFloor, "cache-ttl-floor", 3600*time.Second, "Minimum TTL for cached entries")
+	rootCmd.Flags().DurationVar(&app.ConnectionTimeout, "connection-timeout", 500*time.Millisecond, "Timeout for upstream DNS queries")
 	rootCmd.Flags().BoolVar(&app.RequireProxyProtocol, "require-proxy-protocol", false, "Require PROXY protocol header for DoT connections")
 	rootCmd.Flags().StringSliceVar(&app.TrustedProxies, "trusted-proxies", nil, "Comma-separated list of trusted proxy IP addresses or CIDR ranges")
 


### PR DESCRIPTION
- Added `connection-timeout` flag to control upstream DNS query timeouts.
- Implemented retry logic in `RoundRobinClient` to fall over to the next upstream on network/timeout errors.
- Updated `cache-reaper` cron schedule default.