### PR TITLE
feat: implement asynchronous telemetry workers

### DIFF
--- a/internal/forwarder/cache.go
+++ b/internal/forwarder/cache.go
@@ -26,7 +26,10 @@ type DNSCache struct {
 }
 
 func NewDNSCache(maxSize int, logger *slog.Logger) *DNSCache {
-	logger.Info("Initializing DNS cache", "maxCacheSize", maxSize, "updateBufferSize", CACHE_UPDATE_BUFFER_SIZE)
+	logger.Info("Initializing DNS cache",
+		"max_cache_size", maxSize,
+		"update_buffer_size", CACHE_UPDATE_BUFFER_SIZE)
+
 	c := cache.NewCache[string, []dns.RR]().WithMaxKeys(maxSize).WithLRU()
 
 	dc := &DNSCache{

--- a/internal/forwarder/cache.go
+++ b/internal/forwarder/cache.go
@@ -19,7 +19,7 @@ type cacheUpdate struct {
 type DNSCache struct {
 	cache    cache.Cache[string, []dns.RR]
 	logger   *slog.Logger
-	update   chan cacheUpdate
+	updateCh chan cacheUpdate
 	done     chan struct{}
 	onDrop   func()
 	lastWarn time.Time
@@ -33,10 +33,10 @@ func NewDNSCache(maxSize int, logger *slog.Logger) *DNSCache {
 	c := cache.NewCache[string, []dns.RR]().WithMaxKeys(maxSize).WithLRU()
 
 	dc := &DNSCache{
-		cache:  c,
-		logger: logger,
-		update: make(chan cacheUpdate, CACHE_UPDATE_BUFFER_SIZE),
-		done:   make(chan struct{}),
+		cache:    c,
+		logger:   logger,
+		updateCh: make(chan cacheUpdate, CACHE_UPDATE_BUFFER_SIZE),
+		done:     make(chan struct{}),
 	}
 
 	go dc.runUpdateWorker()
@@ -48,7 +48,7 @@ func NewDNSCache(maxSize int, logger *slog.Logger) *DNSCache {
 func (dc *DNSCache) runUpdateWorker() {
 	for {
 		select {
-		case update, ok := <-dc.update:
+		case update, ok := <-dc.updateCh:
 			if !ok {
 				return
 			}
@@ -83,7 +83,7 @@ func (dc *DNSCache) Set(key string, values []dns.RR, ttl time.Duration) {
 	select {
 	case <-dc.done:
 		return
-	case dc.update <- cacheUpdate{key: key, values: values, ttl: ttl}:
+	case dc.updateCh <- cacheUpdate{key: key, values: values, ttl: ttl}:
 	default:
 		if dc.onDrop != nil {
 			dc.onDrop()

--- a/internal/forwarder/dispatcher.go
+++ b/internal/forwarder/dispatcher.go
@@ -15,6 +15,7 @@ import (
 )
 
 const NUM_WORKERS = 4
+const TELEMETRY_BUFFER_SIZE = 1024
 
 type DNSSource string
 
@@ -48,6 +49,7 @@ type DNSDispatcher struct {
 	metrics     *metrics.DnsMetrics
 	logger      *slog.Logger
 	telemetryCh chan TelemetryEvent
+	done        chan struct{}
 }
 
 func NewDNSDispatcher(
@@ -78,7 +80,8 @@ func NewDNSDispatcher(
 		geoIpLookup: geoIpLookup,
 		metrics:     metrics,
 		logger:      logger,
-		telemetryCh: make(chan TelemetryEvent, 1024),
+		telemetryCh: make(chan TelemetryEvent, TELEMETRY_BUFFER_SIZE),
+		done:        make(chan struct{}),
 	}
 
 	for range NUM_WORKERS {
@@ -91,6 +94,7 @@ func NewDNSDispatcher(
 
 func (d *DNSDispatcher) Close() {
 	d.cache.Close()
+	close(d.done)
 }
 
 func (d *DNSDispatcher) HandleDNSRequest(source DNSSource) DispatcherFunc {
@@ -164,8 +168,16 @@ func (d *DNSDispatcher) HandleDNSRequest(source DNSSource) DispatcherFunc {
 }
 
 func (d *DNSDispatcher) telemetryWorker() {
-	for event := range d.telemetryCh {
-		d.recordTelemetry(event.ctx, event.latency)
+	for {
+		select {
+		case event, ok := <-d.telemetryCh:
+			if !ok {
+				return
+			}
+			d.recordTelemetry(event.ctx, event.latency)
+		case <-d.done:
+			return
+		}
 	}
 }
 

--- a/internal/forwarder/dispatcher.go
+++ b/internal/forwarder/dispatcher.go
@@ -14,6 +14,8 @@ import (
 	"github.com/rm-hull/dot-block/internal/metrics"
 )
 
+const NUM_WORKERS = 4
+
 type DNSSource string
 
 const (
@@ -29,6 +31,11 @@ type RequestContext struct {
 	IpAddr    string
 }
 
+type TelemetryEvent struct {
+	ctx     *RequestContext
+	latency float64
+}
+
 type DispatcherFunc func(writer dns.ResponseWriter, req *dns.Msg)
 
 type DNSDispatcher struct {
@@ -40,6 +47,7 @@ type DNSDispatcher struct {
 	geoIpLookup geoblock.GeoIpLookup
 	metrics     *metrics.DnsMetrics
 	logger      *slog.Logger
+	telemetryCh chan TelemetryEvent
 }
 
 func NewDNSDispatcher(
@@ -61,7 +69,7 @@ func NewDNSDispatcher(
 		return nil, errors.Wrap(err, "failed to initialize metrics")
 	}
 
-	return &DNSDispatcher{
+	d := &DNSDispatcher{
 		dnsClient:   dnsClient,
 		defaultTTL:  300, // TODO: pass in
 		ttlFloor:    ttlFloor,
@@ -70,7 +78,15 @@ func NewDNSDispatcher(
 		geoIpLookup: geoIpLookup,
 		metrics:     metrics,
 		logger:      logger,
-	}, nil
+		telemetryCh: make(chan TelemetryEvent, 1024),
+	}
+
+	for range NUM_WORKERS {
+		go d.telemetryWorker()
+	}
+
+	logger.Info("DNS dispatcher initialized", "num_telemetry_workers", NUM_WORKERS)
+	return d, nil
 }
 
 func (d *DNSDispatcher) Close() {
@@ -91,7 +107,7 @@ func (d *DNSDispatcher) HandleDNSRequest(source DNSSource) DispatcherFunc {
 		}
 
 		ctx := &RequestContext{
-			Logger:    d.logger.With("clientIP", ipAddr, "requestId", req.Id, "source", source),
+			Logger:    d.logger.With("client_ip", ipAddr, "request_id", req.Id, "source", source),
 			Source:    source,
 			StartTime: time.Now(),
 			IpAddr:    ipAddr,
@@ -99,7 +115,11 @@ func (d *DNSDispatcher) HandleDNSRequest(source DNSSource) DispatcherFunc {
 
 		defer func() {
 			duration := time.Since(ctx.StartTime).Seconds()
-			go d.recordTelemetry(ctx, duration)
+			select {
+			case d.telemetryCh <- TelemetryEvent{ctx: ctx, latency: duration}:
+			default:
+				d.metrics.DroppedTelemetry.Inc()
+			}
 		}()
 
 		resp := new(dns.Msg)
@@ -140,6 +160,12 @@ func (d *DNSDispatcher) HandleDNSRequest(source DNSSource) DispatcherFunc {
 		}
 
 		d.sendResponse(ctx, writer, resp)
+	}
+}
+
+func (d *DNSDispatcher) telemetryWorker() {
+	for event := range d.telemetryCh {
+		d.recordTelemetry(event.ctx, event.latency)
 	}
 }
 

--- a/internal/metrics/dns_metrics.go
+++ b/internal/metrics/dns_metrics.go
@@ -32,20 +32,21 @@ func (s *SafeSketch) Estimate() uint64 {
 }
 
 type DnsMetrics struct {
-	RequestLatency        prometheus.Histogram
-	ErrorCounts           *prometheus.CounterVec
-	RequestCounts         *prometheus.CounterVec
-	QueryCounts           *prometheus.CounterVec
-	ReplyCounts           *prometheus.CounterVec
-	CountryCounts         *prometheus.CounterVec
-	UniqueClients         *SafeSketch
-	TopClients            *SpaceSaver
-	TopDomains            *SpaceSaver
-	TopBlockedDomains     *SpaceSaver
-	UpstreamTTLs          *prometheus.HistogramVec
-	UpstreamLatency       *prometheus.HistogramVec
+	RequestLatency      prometheus.Histogram
+	ErrorCounts         *prometheus.CounterVec
+	RequestCounts       *prometheus.CounterVec
+	QueryCounts         *prometheus.CounterVec
+	ReplyCounts         *prometheus.CounterVec
+	CountryCounts       *prometheus.CounterVec
+	UniqueClients       *SafeSketch
+	TopClients          *SpaceSaver
+	TopDomains          *SpaceSaver
+	TopBlockedDomains   *SpaceSaver
+	UpstreamTTLs        *prometheus.HistogramVec
+	UpstreamLatency     *prometheus.HistogramVec
 	CacheReaperCalls    prometheus.Counter
-	DroppedCacheUpdates   prometheus.Counter
+	DroppedCacheUpdates prometheus.Counter
+	DroppedTelemetry    prometheus.Counter
 }
 
 var latencyBuckets = []float64{
@@ -158,6 +159,11 @@ func NewDNSMetrics(cache Cache) (*DnsMetrics, error) {
 		Help: "Total number of cache updates dropped because the update channel was full",
 	})
 
+	droppedTelemetry := prometheus.NewCounter(prometheus.CounterOpts{
+		Name: "dns_dropped_telemetry_total",
+		Help: "Total number of telemetry events dropped because the worker channel was full",
+	})
+
 	if err := shouldRegister(
 		requestLatency,
 		errorCounts,
@@ -174,6 +180,7 @@ func NewDNSMetrics(cache Cache) (*DnsMetrics, error) {
 		upstreamLatency,
 		cacheReaperCalls,
 		droppedCacheUpdates,
+		droppedTelemetry,
 	); err != nil {
 		return nil, errors.Wrap(err, "failed to register DNS metrics")
 	}
@@ -195,6 +202,7 @@ func NewDNSMetrics(cache Cache) (*DnsMetrics, error) {
 		UpstreamLatency:     upstreamLatency,
 		CacheReaperCalls:    cacheReaperCalls,
 		DroppedCacheUpdates: droppedCacheUpdates,
+		DroppedTelemetry:    droppedTelemetry,
 	}, nil
 }
 


### PR DESCRIPTION
Introduced a worker pool pattern for telemetry recording to prevent blocking the main request path.

- Added `telemetryCh` and `NUM_WORKERS` to `DNSDispatcher`.
- Replaced direct goroutine spawning per request with a buffered channel and worker pool.
- Added `dns_dropped_telemetry_total` metric to monitor channel overflows.
- Standardized log field keys to snake_case.