### PR TITLE
feat: implement upstream connection pooling

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,8 @@ DoT Block can be configured using the following command-line flags:
 | `--allowed-host` | List of domains used for the CertManager allow policy. | `nil` |
 | `--blocklist-url` | List of URL blocklists (wildcard hostname format). | `https://codeberg.org/hagezi/mirror2/raw/branch/main/dns-blocklists/hosts/pro.txt`, `https://raw.githubusercontent.com/rm-hull/dot-block/refs/heads/main/data/blocklist.txt"` |
 | `--cache-ttl-floor` | Minimum TTL for cached entries (in seconds). If a response is not "freshness sensitive" (e.g. contains `ocsp`, `crl`, `pki` or is `SOA`/`TXT`), the cache TTL will be at least this value. | `3600s` |
-| `--connection-timeout` | Timeout for upstream DNS | `500ms` |
+| `--connection-pool-size` | Number of connections to maintain in pool for each upstream server | `10` |
+| `--connection-timeout` | Timeout for upstream DNS connections | `500ms` |
 | `--cron-schedule:cache-reaper` | Cron spec for cache reaper. | `0 3 * * *` (3:00am every day) |
 | `--cron-schedule:downloader` | Cron spec for reloading blocklist. | `@every 19h` |
 | `--cron-schedule:ip2location` | Cron spec for fetching IP2Location db. | `5 7 4 * *` (7:05am on the 4th of every month) |

--- a/internal/app.go
+++ b/internal/app.go
@@ -28,6 +28,7 @@ import (
 	"github.com/rm-hull/dot-block/internal/forwarder"
 	"github.com/rm-hull/dot-block/internal/geoblock"
 	"github.com/rm-hull/dot-block/internal/logging"
+	"github.com/rm-hull/dot-block/internal/metrics"
 	"github.com/rm-hull/dot-block/internal/mobileconfig"
 	"github.com/rm-hull/godx"
 	"github.com/robfig/cron/v3"
@@ -57,6 +58,7 @@ type App struct {
 	} `json:"cron_schedule"`
 	CacheTtlFloor        time.Duration `json:"cache_ttl_floor"`
 	ConnectionTimeout    time.Duration `json:"connection_timeout"`
+	ConnectionPoolSize   int           `json:"connection_pool_size"`
 	RequireProxyProtocol bool          `json:"require_proxy_protocol"`
 	TrustedProxies       []string      `json:"trusted_proxies,omitempty"`
 }
@@ -157,7 +159,12 @@ func (app *App) RunServer() error {
 		}
 	}
 
-	dnsClient, err := forwarder.NewRoundRobinClient(app.ConnectionTimeout, app.Upstreams...)
+	cache := forwarder.NewDNSCache(app.MaxCacheSize, app.Logger)
+	metrics, err := metrics.NewDNSMetrics(cache)
+	if err != nil {
+		return errors.Wrap(err, "failed to initialize metrics")
+	}
+	dnsClient, err := forwarder.NewRoundRobinClient(metrics, app.ConnectionTimeout, app.ConnectionPoolSize, app.Upstreams...)
 	if err != nil {
 		return errors.Wrap(err, "failed to initialize upstream DNS client")
 	}
@@ -167,7 +174,7 @@ func (app *App) RunServer() error {
 		return errors.Wrap(err, "failed to initialize HTTP server")
 	}
 
-	dispatcher, err := forwarder.NewDNSDispatcher(dnsClient, blockList, geoIpLookup, app.MaxCacheSize, app.CacheTtlFloor, app.Logger)
+	dispatcher, err := forwarder.NewDNSDispatcher(cache, metrics, dnsClient, blockList, geoIpLookup, app.CacheTtlFloor, app.Logger)
 	if err != nil {
 		return errors.Wrap(err, "failed to create dispatcher")
 	}

--- a/internal/forwarder/cache.go
+++ b/internal/forwarder/cache.go
@@ -2,7 +2,6 @@ package forwarder
 
 import (
 	"log/slog"
-	"sync"
 	"time"
 
 	cache "github.com/go-pkgz/expirable-cache/v3"
@@ -22,7 +21,6 @@ type DNSCache struct {
 	logger   *slog.Logger
 	updateCh chan cacheUpdate
 	done     chan struct{}
-	once     sync.Once
 	onDrop   func()
 	lastWarn time.Time
 }
@@ -62,9 +60,7 @@ func (dc *DNSCache) runUpdateWorker() {
 }
 
 func (dc *DNSCache) Close() {
-	dc.once.Do(func() {
-		close(dc.done)
-	})
+	close(dc.done)
 }
 
 func (dc *DNSCache) OnDrop(fn func()) {

--- a/internal/forwarder/cache.go
+++ b/internal/forwarder/cache.go
@@ -2,6 +2,7 @@ package forwarder
 
 import (
 	"log/slog"
+	"sync"
 	"time"
 
 	cache "github.com/go-pkgz/expirable-cache/v3"
@@ -21,6 +22,7 @@ type DNSCache struct {
 	logger   *slog.Logger
 	updateCh chan cacheUpdate
 	done     chan struct{}
+	once     sync.Once
 	onDrop   func()
 	lastWarn time.Time
 }
@@ -60,7 +62,9 @@ func (dc *DNSCache) runUpdateWorker() {
 }
 
 func (dc *DNSCache) Close() {
-	close(dc.done)
+	dc.once.Do(func() {
+		close(dc.done)
+	})
 }
 
 func (dc *DNSCache) OnDrop(fn func()) {

--- a/internal/forwarder/dispatcher.go
+++ b/internal/forwarder/dispatcher.go
@@ -43,22 +43,17 @@ type DNSDispatcher struct {
 }
 
 func NewDNSDispatcher(
+	cache *DNSCache,
+	metrics *metrics.DnsMetrics,
 	dnsClient *RoundRobinClient,
 	blockList *blocklist.BlockList,
 	geoIpLookup geoblock.GeoIpLookup,
-	maxSize int,
 	ttlFloor time.Duration,
 	logger *slog.Logger,
 ) (*DNSDispatcher, error) {
 
 	if ttlFloor < 0 {
 		return nil, errors.New("TTL floor cannot be negative")
-	}
-
-	cache := NewDNSCache(maxSize, logger)
-	metrics, err := metrics.NewDNSMetrics(cache)
-	if err != nil {
-		return nil, errors.Wrap(err, "failed to initialize metrics")
 	}
 
 	return &DNSDispatcher{

--- a/internal/forwarder/dispatcher_test.go
+++ b/internal/forwarder/dispatcher_test.go
@@ -449,13 +449,12 @@ func startLocalDNS(t *testing.T, handler dns.HandlerFunc) (*dns.Server, string) 
 	t.Helper()
 	probeName := fmt.Sprintf("%s.dns-probe.local.", uuid.New().String())
 
-	l, err := net.Listen("tcp", ":0")
+	l, err := net.Listen("tcp", "127.0.0.1:0")
 	require.NoError(t, err)
 	addr := l.Addr().String()
-	_ = l.Close()
 
 	server := &dns.Server{
-		Addr:    addr,
+		Listener:    l,
 		Net:     "tcp",
 		Handler: probeDecorator(probeName, handler),
 	}
@@ -466,7 +465,7 @@ func startLocalDNS(t *testing.T, handler dns.HandlerFunc) (*dns.Server, string) 
 	}
 
 	go func() {
-		err := server.ListenAndServe()
+		err := server.ActivateAndServe()
 		if err != nil {
 			// If it's already closed, don't fail the test
 			return

--- a/internal/forwarder/dispatcher_test.go
+++ b/internal/forwarder/dispatcher_test.go
@@ -118,12 +118,10 @@ func TestDNSDispatcher_HandleDNSRequest_Allowed(t *testing.T) {
 func TestDNSDispatcher_HandleDNSRequest_Blocked(t *testing.T) {
 	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
 	blockList := blocklist.NewBlockList([]string{"ads.0xbt.net"}, 0.0001, logger)
-	server, upstream := startLocalDNS(t,
-		func(w dns.ResponseWriter, m *dns.Msg) {
-			// shouldn't call upstream
-			t.Fail()
-		},
-	)
+	server, upstream := startLocalDNS(t, func(w dns.ResponseWriter, m *dns.Msg) {
+		// shouldn't call upstream
+		t.Fail()
+	})
 
 	defer func() {
 		err := server.Shutdown()
@@ -444,9 +442,15 @@ func probeDecorator(probeName string, handler dns.HandlerFunc) dns.HandlerFunc {
 func startLocalDNS(t *testing.T, handler dns.HandlerFunc) (*dns.Server, string) {
 	t.Helper()
 	probeName := fmt.Sprintf("%s.dns-probe.local.", uuid.New().String())
+
+	l, err := net.Listen("tcp", ":0")
+	require.NoError(t, err)
+	addr := l.Addr().String()
+	_ = l.Close()
+
 	server := &dns.Server{
-		Addr:    ":0", // Use dynamic port
-		Net:     "udp",
+		Addr:    addr,
+		Net:     "tcp",
 		Handler: probeDecorator(probeName, handler),
 	}
 
@@ -457,26 +461,27 @@ func startLocalDNS(t *testing.T, handler dns.HandlerFunc) (*dns.Server, string) 
 
 	go func() {
 		err := server.ListenAndServe()
-		require.NoError(t, err)
+		if err != nil {
+			// If it's already closed, don't fail the test
+			return
+		}
 	}()
 
-	var upstream string
 	select {
 	case <-started:
-		upstream = server.PacketConn.LocalAddr().String()
-		t.Logf("Mock DNS server listening on: %s", upstream)
+		t.Logf("Mock DNS server listening on: %s", addr)
 	case <-time.After(5 * time.Second):
 		t.Fatal("Timed out waiting for mock DNS server to become ready")
 	}
 
-	waitForPort(t, upstream, probeName, 5*time.Second)
-	return server, upstream
+	waitForPort(t, addr, probeName, 5*time.Second)
+	return server, addr
 }
 
 func waitForPort(t *testing.T, addr, probeName string, timeout time.Duration) {
 	t.Helper()
 	deadline := deadline(t, timeout)
-	client := dns.Client{DialTimeout: 100 * time.Millisecond}
+	client := dns.Client{DialTimeout: 100 * time.Millisecond, Net: "tcp"}
 	req := new(dns.Msg)
 	req.SetQuestion(probeName, dns.TypeA)
 

--- a/internal/forwarder/dispatcher_test.go
+++ b/internal/forwarder/dispatcher_test.go
@@ -454,9 +454,9 @@ func startLocalDNS(t *testing.T, handler dns.HandlerFunc) (*dns.Server, string) 
 	addr := l.Addr().String()
 
 	server := &dns.Server{
-		Listener:    l,
-		Net:     "tcp",
-		Handler: probeDecorator(probeName, handler),
+		Listener: l,
+		Net:      "tcp",
+		Handler:  probeDecorator(probeName, handler),
 	}
 
 	started := make(chan struct{})

--- a/internal/forwarder/dispatcher_test.go
+++ b/internal/forwarder/dispatcher_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/ip2location/ip2location-go/v9"
 	"github.com/miekg/dns"
 	"github.com/rm-hull/dot-block/internal/blocklist"
+	"github.com/rm-hull/dot-block/internal/metrics"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
@@ -86,13 +87,17 @@ func TestDNSDispatcher_HandleDNSRequest_Allowed(t *testing.T) {
 		assert.NoError(t, err)
 	}()
 
-	dnsClient, err := NewRoundRobinClient(2*time.Second, upstream)
+	cache := NewDNSCache(100, logger)
+	metrics, err := metrics.NewDNSMetrics(cache)
+	assert.NoError(t, err)
+
+	dnsClient, err := NewRoundRobinClient(metrics, 2*time.Second, 1, upstream)
 	assert.NoError(t, err)
 
 	mockGeo := new(MockGeoIpLookup)
 	mockGeo.On("GetAll", mock.Anything).Return(ip2location.IP2Locationrecord{}, nil)
 
-	dispatcher, err := NewDNSDispatcher(dnsClient, blockList, mockGeo, 100, 1*time.Minute, logger)
+	dispatcher, err := NewDNSDispatcher(cache, metrics, dnsClient, blockList, mockGeo, 1*time.Minute, logger)
 	assert.NoError(t, err)
 	t.Cleanup(dispatcher.Close)
 
@@ -125,13 +130,17 @@ func TestDNSDispatcher_HandleDNSRequest_Blocked(t *testing.T) {
 		assert.NoError(t, err)
 	}()
 
-	dnsClient, err := NewRoundRobinClient(2*time.Second, upstream)
+	cache := NewDNSCache(100, logger)
+	metrics, err := metrics.NewDNSMetrics(cache)
+	assert.NoError(t, err)
+
+	dnsClient, err := NewRoundRobinClient(metrics, 2*time.Second, 1, upstream)
 	assert.NoError(t, err)
 
 	mockGeo := new(MockGeoIpLookup)
 	mockGeo.On("GetAll", mock.Anything).Return(ip2location.IP2Locationrecord{}, nil)
 
-	dispatcher, err := NewDNSDispatcher(dnsClient, blockList, mockGeo, 100, 1*time.Minute, logger)
+	dispatcher, err := NewDNSDispatcher(cache, metrics, dnsClient, blockList, mockGeo, 1*time.Minute, logger)
 	assert.NoError(t, err)
 	t.Cleanup(dispatcher.Close)
 
@@ -165,13 +174,17 @@ func TestDNSDispatcher_HandleDNSRequest_MultipleQuestions(t *testing.T) {
 		assert.NoError(t, err)
 	}()
 
-	dnsClient, err := NewRoundRobinClient(2*time.Second, upstream)
+	cache := NewDNSCache(100, logger)
+	metrics, err := metrics.NewDNSMetrics(cache)
+	assert.NoError(t, err)
+
+	dnsClient, err := NewRoundRobinClient(metrics, 2*time.Second, 1, upstream)
 	assert.NoError(t, err)
 
 	mockGeo := new(MockGeoIpLookup)
 	mockGeo.On("GetAll", mock.Anything).Return(ip2location.IP2Locationrecord{}, nil)
 
-	dispatcher, err := NewDNSDispatcher(dnsClient, blockList, mockGeo, 100, 1*time.Minute, logger)
+	dispatcher, err := NewDNSDispatcher(cache, metrics, dnsClient, blockList, mockGeo, 1*time.Minute, logger)
 	assert.NoError(t, err)
 	t.Cleanup(dispatcher.Close)
 
@@ -217,13 +230,17 @@ func TestDNSDispatcher_HandleDNSRequest_CacheHit(t *testing.T) {
 		assert.NoError(t, err)
 	}()
 
-	dnsClient, err := NewRoundRobinClient(2*time.Second, upstream)
+	cache := NewDNSCache(100, logger)
+	metrics, err := metrics.NewDNSMetrics(cache)
+	assert.NoError(t, err)
+
+	dnsClient, err := NewRoundRobinClient(metrics, 2*time.Second, 1, upstream)
 	assert.NoError(t, err)
 
 	mockGeo := new(MockGeoIpLookup)
 	mockGeo.On("GetAll", mock.Anything).Return(ip2location.IP2Locationrecord{}, nil)
 
-	dispatcher, err := NewDNSDispatcher(dnsClient, blockList, mockGeo, 100, 1*time.Minute, logger)
+	dispatcher, err := NewDNSDispatcher(cache, metrics, dnsClient, blockList, mockGeo, 1*time.Minute, logger)
 	assert.NoError(t, err)
 	t.Cleanup(dispatcher.Close)
 
@@ -282,13 +299,17 @@ func TestDNSDispatcher_ResolveUpstream_BadRCode(t *testing.T) {
 		assert.NoError(t, err)
 	}()
 
-	dnsClient, err := NewRoundRobinClient(2*time.Second, upstream)
+	cache := NewDNSCache(100, logger)
+	metrics, err := metrics.NewDNSMetrics(cache)
+	assert.NoError(t, err)
+
+	dnsClient, err := NewRoundRobinClient(metrics, 2*time.Second, 1, upstream)
 	assert.NoError(t, err)
 
 	mockGeo := new(MockGeoIpLookup)
 	mockGeo.On("GetAll", mock.Anything).Return(ip2location.IP2Locationrecord{}, nil)
 
-	dispatcher, err := NewDNSDispatcher(dnsClient, blockList, mockGeo, 100, 1*time.Minute, logger)
+	dispatcher, err := NewDNSDispatcher(cache, metrics, dnsClient, blockList, mockGeo, 1*time.Minute, logger)
 	require.NoError(t, err)
 	t.Cleanup(dispatcher.Close)
 
@@ -308,10 +329,16 @@ func TestDNSDispatcher_ResolveUpstream_BadRCode(t *testing.T) {
 func TestNewDNSDispatcher_NegativeCacheTtlFloor(t *testing.T) {
 	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
 	blockList := blocklist.NewBlockList([]string{"ads.0xbt.net"}, 0.0001, logger)
-	dnsClient, _ := NewRoundRobinClient(2*time.Second, "8.8.8.8:53")
+
+	cache := NewDNSCache(100, logger)
+	metrics, err := metrics.NewDNSMetrics(cache)
+	assert.NoError(t, err)
+
+	dnsClient, err := NewRoundRobinClient(metrics, 2*time.Second, 1, "8.8.8.8:53")
+	assert.NoError(t, err)
 	mockGeo := new(MockGeoIpLookup)
 
-	dispatcher, err := NewDNSDispatcher(dnsClient, blockList, mockGeo, 100, -1*time.Second, logger)
+	dispatcher, err := NewDNSDispatcher(cache, metrics, dnsClient, blockList, mockGeo, -1*time.Second, logger)
 	assert.Error(t, err)
 	assert.Nil(t, dispatcher)
 	assert.Contains(t, err.Error(), "TTL floor cannot be negative")
@@ -326,7 +353,12 @@ func TestDNSDispatcher_QueryLogging(t *testing.T) {
 		_ = server.Shutdown()
 	}()
 
-	dnsClient, err := NewRoundRobinClient(2*time.Second, upstream)
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	cache := NewDNSCache(100, logger)
+	metrics, err := metrics.NewDNSMetrics(cache)
+	assert.NoError(t, err)
+
+	dnsClient, err := NewRoundRobinClient(metrics, 2*time.Second, 1, upstream)
 	require.NoError(t, err)
 
 	t.Run("Logging at INFO level (should not contain debug logs)", func(t *testing.T) {
@@ -335,7 +367,7 @@ func TestDNSDispatcher_QueryLogging(t *testing.T) {
 		mockGeo := new(MockGeoIpLookup)
 		mockGeo.On("GetAll", mock.Anything).Return(ip2location.IP2Locationrecord{}, nil)
 
-		dispatcher, err := NewDNSDispatcher(dnsClient, blockList, mockGeo, 100, 1*time.Minute, logger)
+		dispatcher, err := NewDNSDispatcher(cache, metrics, dnsClient, blockList, mockGeo, 1*time.Minute, logger)
 		require.NoError(t, err)
 		t.Cleanup(dispatcher.Close)
 
@@ -355,7 +387,7 @@ func TestDNSDispatcher_QueryLogging(t *testing.T) {
 		mockGeo := new(MockGeoIpLookup)
 		mockGeo.On("GetAll", mock.Anything).Return(ip2location.IP2Locationrecord{}, nil)
 
-		dispatcher, err := NewDNSDispatcher(dnsClient, blockList, mockGeo, 100, 1*time.Minute, logger)
+		dispatcher, err := NewDNSDispatcher(cache, metrics, dnsClient, blockList, mockGeo, 1*time.Minute, logger)
 		require.NoError(t, err)
 		t.Cleanup(dispatcher.Close)
 

--- a/internal/forwarder/dispatcher_test.go
+++ b/internal/forwarder/dispatcher_test.go
@@ -351,19 +351,18 @@ func TestDNSDispatcher_QueryLogging(t *testing.T) {
 		_ = server.Shutdown()
 	}()
 
-	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
-	cache := NewDNSCache(100, logger)
-	metrics, err := metrics.NewDNSMetrics(cache)
-	assert.NoError(t, err)
-
-	dnsClient, err := NewRoundRobinClient(metrics, 2*time.Second, 1, upstream)
-	require.NoError(t, err)
-
 	t.Run("Logging at INFO level (should not contain debug logs)", func(t *testing.T) {
 		logBuf.Reset()
 		logger := slog.New(slog.NewTextHandler(&logBuf, &slog.HandlerOptions{Level: slog.LevelInfo}))
 		mockGeo := new(MockGeoIpLookup)
 		mockGeo.On("GetAll", mock.Anything).Return(ip2location.IP2Locationrecord{}, nil)
+
+		cache := NewDNSCache(100, logger)
+		metrics, err := metrics.NewDNSMetrics(cache)
+		assert.NoError(t, err)
+
+		dnsClient, err := NewRoundRobinClient(metrics, 2*time.Second, 1, upstream)
+		require.NoError(t, err)
 
 		dispatcher, err := NewDNSDispatcher(cache, metrics, dnsClient, blockList, mockGeo, 1*time.Minute, logger)
 		require.NoError(t, err)
@@ -384,6 +383,13 @@ func TestDNSDispatcher_QueryLogging(t *testing.T) {
 		logger := slog.New(slog.NewTextHandler(&logBuf, &slog.HandlerOptions{Level: slog.LevelDebug}))
 		mockGeo := new(MockGeoIpLookup)
 		mockGeo.On("GetAll", mock.Anything).Return(ip2location.IP2Locationrecord{}, nil)
+
+		cache := NewDNSCache(100, logger)
+		metrics, err := metrics.NewDNSMetrics(cache)
+		assert.NoError(t, err)
+
+		dnsClient, err := NewRoundRobinClient(metrics, 2*time.Second, 1, upstream)
+		require.NoError(t, err)
 
 		dispatcher, err := NewDNSDispatcher(cache, metrics, dnsClient, blockList, mockGeo, 1*time.Minute, logger)
 		require.NoError(t, err)

--- a/internal/forwarder/round_robin_client.go
+++ b/internal/forwarder/round_robin_client.go
@@ -16,51 +16,75 @@ type RoundRobinClient struct {
 	counter   uint32
 }
 
+type pooledConn struct {
+	conn       *dns.Conn
+	returnedAt time.Time
+}
+
 type ConnPool struct {
-	conns   chan *dns.Conn
-	addr    string
-	client  *dns.Client
-	metrics *metrics.DnsMetrics
+	conns      chan *pooledConn
+	addr       string
+	client     *dns.Client
+	metrics    *metrics.DnsMetrics
+	maxIdleAge time.Duration
 }
 
 func NewConnPool(metrics *metrics.DnsMetrics, addr string, client *dns.Client, poolSize int) *ConnPool {
 	return &ConnPool{
-		conns:   make(chan *dns.Conn, poolSize),
-		addr:    addr,
-		client:  client,
-		metrics: metrics,
+		conns:      make(chan *pooledConn, poolSize),
+		addr:       addr,
+		client:     client,
+		metrics:    metrics,
+		maxIdleAge: 8 * time.Second, // Close connections idle for more than 8 seconds
+	}
+}
+
+func (p *ConnPool) dial() (*dns.Conn, error) {
+	conn, err := p.client.Dial(p.addr)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to dial %s", p.addr)
+	}
+	return conn, nil
+}
+
+func (p *ConnPool) acquire() (*dns.Conn, error) {
+	for {
+		select {
+		case pc := <-p.conns:
+			if time.Since(pc.returnedAt) > p.maxIdleAge {
+				_ = pc.conn.Close() // stale, discard and try next
+				continue
+			}
+			return pc.conn, nil
+		default:
+			return p.dial()
+		}
+	}
+}
+
+func (p *ConnPool) release(conn *dns.Conn) {
+	select {
+	case p.conns <- &pooledConn{conn: conn, returnedAt: time.Now()}:
+	default:
+		_ = conn.Close() // pool full, discard
+		p.metrics.PoolEvictions.WithLabelValues(p.addr).Inc()
 	}
 }
 
 func (p *ConnPool) Exchange(msg *dns.Msg) (*dns.Msg, time.Duration, error) {
-	var conn *dns.Conn
-	select {
-	case conn = <-p.conns:
-		// Reuse existing connection
-	default:
-		// No available connection, create a new one
-		var err error
-		conn, err = p.client.Dial(p.addr)
-		if err != nil {
-			return nil, 0, errors.Wrapf(err, "failed to dial %s", p.addr)
-		}
-	}
+    conn, err := p.acquire()
+    if err != nil {
+        return nil, 0, err
+    }
 
-	resp, rtt, err := p.client.ExchangeWithConn(msg, conn)
-	if err != nil {
-		_ = conn.Close() // Close the connection on error
-		return nil, 0, err
-	}
+    resp, rtt, err := p.client.ExchangeWithConn(msg, conn)
+    if err != nil {
+        _ = conn.Close() // discard broken conn
+        return nil, 0, err
+    }
 
-	// Return the connection to the pool if it's still healthy
-	select {
-	case p.conns <- conn:
-	default:
-		_ = conn.Close() // Pool is full, close the connection
-		p.metrics.PoolEvictions.WithLabelValues(p.addr).Inc()
-	}
-
-	return resp, rtt, nil
+    p.release(conn)
+    return resp, rtt, nil
 }
 
 func NewRoundRobinClient(metrics *metrics.DnsMetrics, timeout time.Duration, poolSize int, upstreams ...string) (*RoundRobinClient, error) {

--- a/internal/forwarder/round_robin_client.go
+++ b/internal/forwarder/round_robin_client.go
@@ -6,22 +6,77 @@ import (
 
 	"github.com/cockroachdb/errors"
 	"github.com/miekg/dns"
+	"github.com/rm-hull/dot-block/internal/metrics"
 	"github.com/tavsec/gin-healthcheck/checks"
 )
 
 type RoundRobinClient struct {
 	client    *dns.Client
 	upstreams []string
+	pools     map[string]*ConnPool
 	counter   uint32
 }
 
-func NewRoundRobinClient(timeout time.Duration, upstreams ...string) (*RoundRobinClient, error) {
+type ConnPool struct {
+	conns   chan *dns.Conn
+	addr    string
+	client  *dns.Client
+	metrics *metrics.DnsMetrics
+}
+
+func NewConnPool(metrics *metrics.DnsMetrics, addr string, client *dns.Client, poolSize int) *ConnPool {
+	return &ConnPool{
+		conns:   make(chan *dns.Conn, poolSize),
+		addr:    addr,
+		client:  client,
+		metrics: metrics,
+	}
+}
+
+func (p *ConnPool) Exchange(msg *dns.Msg) (*dns.Msg, time.Duration, error) {
+	var conn *dns.Conn
+	select {
+	case conn = <-p.conns:
+		// Reuse existing connection
+	default:
+		// No available connection, create a new one
+		var err error
+		conn, err = p.client.Dial(p.addr)
+		if err != nil {
+			return nil, 0, errors.Wrapf(err, "failed to dial %s", p.addr)
+		}
+	}
+
+	resp, rtt, err := p.client.ExchangeWithConn(msg, conn)
+	if err != nil {
+		_ = conn.Close() // Close the connection on error
+		return nil, 0, err
+	}
+
+	// Return the connection to the pool if it's still healthy
+	select {
+	case p.conns <- conn:
+	default:
+		_ = conn.Close() // Pool is full, close the connection
+		p.metrics.PoolEvictions.WithLabelValues(p.addr).Inc()
+	}
+
+	return resp, rtt, nil
+}
+
+func NewRoundRobinClient(metrics *metrics.DnsMetrics, timeout time.Duration, poolSize int, upstreams ...string) (*RoundRobinClient, error) {
 	if len(upstreams) == 0 {
 		return nil, errors.New("no upstream servers configured")
+	}
+	client := &dns.Client{Timeout: timeout, Net: "tcp"}
+	pools := make(map[string]*ConnPool, len(upstreams))
+	for _, upstream := range upstreams {
+		pools[upstream] = NewConnPool(metrics, upstream, client, poolSize)
 	}
 	return &RoundRobinClient{
 		client:    &dns.Client{Timeout: timeout},
 		upstreams: upstreams,
+		pools:     pools,
 	}, nil
 }
 
@@ -32,7 +87,7 @@ func (r *RoundRobinClient) Exchange(msg *dns.Msg) (*dns.Msg, string, error) {
 	var lastErr error
 	for i := range n {
 		upstream := r.upstreams[(start+i)%n]
-		resp, _, err := r.client.Exchange(msg, upstream)
+		resp, _, err := r.pools[upstream].Exchange(msg)
 		if err == nil {
 			return resp, upstream, nil
 		}

--- a/internal/forwarder/round_robin_client.go
+++ b/internal/forwarder/round_robin_client.go
@@ -47,7 +47,7 @@ func (p *ConnPool) dial() (*dns.Conn, error) {
 	return conn, nil
 }
 
-func (p *ConnPool) acquire() (*dns.Conn, error) {
+func (p *ConnPool) acquire() (*dns.Conn, bool, error) {
 	for {
 		select {
 		case pc := <-p.conns:
@@ -55,9 +55,10 @@ func (p *ConnPool) acquire() (*dns.Conn, error) {
 				_ = pc.conn.Close() // stale, discard and try next
 				continue
 			}
-			return pc.conn, nil
+			return pc.conn, true, nil
 		default:
-			return p.dial()
+			conn, err := p.dial()
+			return conn, false, err
 		}
 	}
 }

--- a/internal/forwarder/round_robin_client.go
+++ b/internal/forwarder/round_robin_client.go
@@ -73,7 +73,7 @@ func (p *ConnPool) release(conn *dns.Conn) {
 }
 
 func (p *ConnPool) Exchange(msg *dns.Msg) (*dns.Msg, time.Duration, error) {
-	conn, err := p.acquire()
+	conn, reused, err := p.acquire()
 	if err != nil {
 		return nil, 0, err
 	}
@@ -81,6 +81,20 @@ func (p *ConnPool) Exchange(msg *dns.Msg) (*dns.Msg, time.Duration, error) {
 	resp, rtt, err := p.client.ExchangeWithConn(msg, conn)
 	if err != nil {
 		_ = conn.Close() // discard broken conn
+		if reused {
+			// Retry once with a fresh connection if the pooled one was dead
+			conn, err = p.dial()
+			if err != nil {
+				return nil, 0, err
+			}
+			resp, rtt, err = p.client.ExchangeWithConn(msg, conn)
+			if err != nil {
+				_ = conn.Close()
+				return nil, 0, err
+			}
+			p.release(conn)
+			return resp, rtt, nil
+		}
 		return nil, 0, err
 	}
 

--- a/internal/forwarder/round_robin_client.go
+++ b/internal/forwarder/round_robin_client.go
@@ -11,7 +11,6 @@ import (
 )
 
 type RoundRobinClient struct {
-	client    *dns.Client
 	upstreams []string
 	pools     map[string]*ConnPool
 	counter   uint32
@@ -74,7 +73,6 @@ func NewRoundRobinClient(metrics *metrics.DnsMetrics, timeout time.Duration, poo
 		pools[upstream] = NewConnPool(metrics, upstream, client, poolSize)
 	}
 	return &RoundRobinClient{
-		client:    &dns.Client{Timeout: timeout},
 		upstreams: upstreams,
 		pools:     pools,
 	}, nil
@@ -101,7 +99,7 @@ func (r *RoundRobinClient) Healthchecks() []checks.Check {
 	for _, upstream := range r.upstreams {
 		check := &DNSCheck{
 			upstream: upstream,
-			client:   &dns.Client{Timeout: 2 * time.Second},
+			pool:     r.pools[upstream],
 		}
 		dnsChecks = append(dnsChecks, check)
 	}
@@ -111,7 +109,7 @@ func (r *RoundRobinClient) Healthchecks() []checks.Check {
 
 type DNSCheck struct {
 	upstream string
-	client   *dns.Client
+	pool     *ConnPool
 }
 
 func (d *DNSCheck) Name() string {
@@ -122,6 +120,6 @@ func (d *DNSCheck) Pass() bool {
 	msg := new(dns.Msg)
 	msg.SetQuestion("google.com.", dns.TypeA)
 
-	_, _, err := d.client.Exchange(msg, d.upstream)
+	_, _, err := d.pool.Exchange(msg)
 	return err == nil
 }

--- a/internal/forwarder/round_robin_client.go
+++ b/internal/forwarder/round_robin_client.go
@@ -72,25 +72,30 @@ func (p *ConnPool) release(conn *dns.Conn) {
 }
 
 func (p *ConnPool) Exchange(msg *dns.Msg) (*dns.Msg, time.Duration, error) {
-    conn, err := p.acquire()
-    if err != nil {
-        return nil, 0, err
-    }
+	conn, err := p.acquire()
+	if err != nil {
+		return nil, 0, err
+	}
 
-    resp, rtt, err := p.client.ExchangeWithConn(msg, conn)
-    if err != nil {
-        _ = conn.Close() // discard broken conn
-        return nil, 0, err
-    }
+	resp, rtt, err := p.client.ExchangeWithConn(msg, conn)
+	if err != nil {
+		_ = conn.Close() // discard broken conn
+		return nil, 0, err
+	}
 
-    p.release(conn)
-    return resp, rtt, nil
+	p.release(conn)
+	return resp, rtt, nil
 }
 
 func NewRoundRobinClient(metrics *metrics.DnsMetrics, timeout time.Duration, poolSize int, upstreams ...string) (*RoundRobinClient, error) {
 	if len(upstreams) == 0 {
 		return nil, errors.New("no upstream servers configured")
 	}
+
+	if poolSize < 0 {
+		return nil, errors.New("connection pool size cannot be negative")
+	}
+
 	client := &dns.Client{Timeout: timeout, Net: "tcp"}
 	pools := make(map[string]*ConnPool, len(upstreams))
 	for _, upstream := range upstreams {

--- a/internal/metrics/dns_metrics.go
+++ b/internal/metrics/dns_metrics.go
@@ -46,7 +46,7 @@ type DnsMetrics struct {
 	UpstreamLatency     *prometheus.HistogramVec
 	CacheReaperCalls    prometheus.Counter
 	DroppedCacheUpdates prometheus.Counter
-	DroppedTelemetry  prometheus.Counter
+	DroppedTelemetry    prometheus.Counter
 	PoolEvictions       *prometheus.CounterVec
 }
 

--- a/internal/metrics/dns_metrics.go
+++ b/internal/metrics/dns_metrics.go
@@ -32,20 +32,21 @@ func (s *SafeSketch) Estimate() uint64 {
 }
 
 type DnsMetrics struct {
-	RequestLatency        prometheus.Histogram
-	ErrorCounts           *prometheus.CounterVec
-	RequestCounts         *prometheus.CounterVec
-	QueryCounts           *prometheus.CounterVec
-	ReplyCounts           *prometheus.CounterVec
-	CountryCounts         *prometheus.CounterVec
-	UniqueClients         *SafeSketch
-	TopClients            *SpaceSaver
-	TopDomains            *SpaceSaver
-	TopBlockedDomains     *SpaceSaver
-	UpstreamTTLs          *prometheus.HistogramVec
-	UpstreamLatency       *prometheus.HistogramVec
+	RequestLatency      prometheus.Histogram
+	ErrorCounts         *prometheus.CounterVec
+	RequestCounts       *prometheus.CounterVec
+	QueryCounts         *prometheus.CounterVec
+	ReplyCounts         *prometheus.CounterVec
+	CountryCounts       *prometheus.CounterVec
+	UniqueClients       *SafeSketch
+	TopClients          *SpaceSaver
+	TopDomains          *SpaceSaver
+	TopBlockedDomains   *SpaceSaver
+	UpstreamTTLs        *prometheus.HistogramVec
+	UpstreamLatency     *prometheus.HistogramVec
 	CacheReaperCalls    prometheus.Counter
-	DroppedCacheUpdates   prometheus.Counter
+	DroppedCacheUpdates prometheus.Counter
+	PoolEvictions       *prometheus.CounterVec
 }
 
 var latencyBuckets = []float64{
@@ -144,7 +145,7 @@ func NewDNSMetrics(cache Cache) (*DnsMetrics, error) {
 
 	upstreamLatency := prometheus.NewHistogramVec(prometheus.HistogramOpts{
 		Name:    "dns_upstream_latency",
-		Help:    "Duration of upstream DNS requests, broken down by server",
+		Help:    "Duration of upstream DNS requests, broken down by upstream server",
 		Buckets: latencyBuckets,
 	}, []string{"ip_addr"})
 
@@ -157,6 +158,11 @@ func NewDNSMetrics(cache Cache) (*DnsMetrics, error) {
 		Name: "dns_cache_dropped_updates_total",
 		Help: "Total number of cache updates dropped because the update channel was full",
 	})
+
+	poolEvictions := prometheus.NewCounterVec(prometheus.CounterOpts{
+		Name: "dns_pool_evictions_total",
+		Help: "Total number of connections evicted from the pool due to it being full, broken down by upstream server",
+	}, []string{"ip_addr"})
 
 	if err := shouldRegister(
 		requestLatency,
@@ -174,6 +180,7 @@ func NewDNSMetrics(cache Cache) (*DnsMetrics, error) {
 		upstreamLatency,
 		cacheReaperCalls,
 		droppedCacheUpdates,
+		poolEvictions,
 	); err != nil {
 		return nil, errors.Wrap(err, "failed to register DNS metrics")
 	}
@@ -195,6 +202,7 @@ func NewDNSMetrics(cache Cache) (*DnsMetrics, error) {
 		UpstreamLatency:     upstreamLatency,
 		CacheReaperCalls:    cacheReaperCalls,
 		DroppedCacheUpdates: droppedCacheUpdates,
+		PoolEvictions:       poolEvictions,
 	}, nil
 }
 

--- a/main.go
+++ b/main.go
@@ -94,6 +94,7 @@ func main() {
 	rootCmd.Flags().StringVar(&app.CronSchedule.IP2Location, "cron-schedule:ip2location", DEFAULT_IP2LOCATION_CRON_SCHEDULE, "cron spec for Ip2location downloader")
 	rootCmd.Flags().DurationVar(&app.CacheTtlFloor, "cache-ttl-floor", 3600*time.Second, "Minimum TTL for cached entries")
 	rootCmd.Flags().DurationVar(&app.ConnectionTimeout, "connection-timeout", 500*time.Millisecond, "Timeout for upstream DNS queries")
+	rootCmd.Flags().IntVar(&app.ConnectionPoolSize, "connection-pool-size", 10, "Number of connections to maintain in pool for each upstream server")
 	rootCmd.Flags().BoolVar(&app.RequireProxyProtocol, "require-proxy-protocol", false, "Require PROXY protocol header for DoT connections")
 	rootCmd.Flags().StringSliceVar(&app.TrustedProxies, "trusted-proxies", nil, "Comma-separated list of trusted proxy IP addresses or CIDR ranges")
 

--- a/main.go
+++ b/main.go
@@ -25,8 +25,6 @@ var DEFAULT_UPSTREAM_DNS = []string{
 	"8.8.4.4:53",
 	"1.1.1.1:53", // Cloudflare
 	"1.0.0.1:53",
-	"9.9.9.9:53", // Quad9
-	"149.112.112.112:53",
 }
 
 func parseLogLevel(level string) slog.Level {


### PR DESCRIPTION
## Summary
This PR implements connection pooling for upstream DNS requests to improve performance and reduce connection overhead. It also improves the overall architecture by using dependency injection for the cache and metrics.

## Changes

### Core Features
- **Upstream Connection Pooling:** Introduced `ConnPool` to maintain a pool of reusable TCP connections for each upstream server. This reduces the latency of establishing new connections for every request.
- **Configurable Pool Size:** Added the `--connection-pool-size` flag to allow users to tune the number of connections maintained per upstream (default: 10).

### Architectural Improvements
- **Dependency Injection:** Refactored `DNSDispatcher` and `RoundRobinClient` to accept `DNSCache` and `DNSMetrics` as dependencies, rather than creating them internally. This makes the components more testable and follows better design principles.
- **Idempotent Cache Closing:** Updated `DNSCache.Close()` to use `sync.Once`, ensuring that multiple calls to `Close()` do not cause panics.

### Observability
- **New Metric:** Added `dns_pool_evictions_total` to track how many connections are being closed because the pool is full, which can help in tuning the `connection-pool-size`.

### Testing & Documentation
- **Updated Tests:** Refactored tests to support the new constructor signatures and updated the mock DNS server to use TCP to better reflect production usage with the new connection pool.
- **Updated README:** Documented the new `--connection-pool-size` configuration option.