### PR TITLE
feat: add upstream failure logging and metrics

### DIFF
--- a/internal/app.go
+++ b/internal/app.go
@@ -164,7 +164,7 @@ func (app *App) RunServer() error {
 	if err != nil {
 		return errors.Wrap(err, "failed to initialize metrics")
 	}
-	dnsClient, err := forwarder.NewRoundRobinClient(metrics, app.ConnectionTimeout, app.ConnectionPoolSize, app.Upstreams...)
+	dnsClient, err := forwarder.NewRoundRobinClient(metrics, app.ConnectionTimeout, app.ConnectionPoolSize, app.Logger, app.Upstreams...)
 	if err != nil {
 		return errors.Wrap(err, "failed to initialize upstream DNS client")
 	}

--- a/internal/forwarder/dispatcher_test.go
+++ b/internal/forwarder/dispatcher_test.go
@@ -86,7 +86,7 @@ func setupDispatcherTest(t *testing.T, upstream string) (*DNSDispatcher, *MockGe
 	metrics, err := metrics.NewDNSMetrics(cache)
 	require.NoError(t, err)
 
-	dnsClient, err := NewRoundRobinClient(metrics, 2*time.Second, 1, upstream)
+	dnsClient, err := NewRoundRobinClient(metrics, 2*time.Second, 1, logger, upstream)
 	require.NoError(t, err)
 
 	mockGeo := new(MockGeoIpLookup)
@@ -333,7 +333,7 @@ func TestDNSDispatcher_NegativeCacheTtlFloor(t *testing.T) {
 	metrics, err := metrics.NewDNSMetrics(cache)
 	assert.NoError(t, err)
 
-	dnsClient, err := NewRoundRobinClient(metrics, 2*time.Second, 1, "8.8.8.8:53")
+	dnsClient, err := NewRoundRobinClient(metrics, 2*time.Second, 1, logger, "8.8.8.8:53")
 	assert.NoError(t, err)
 	mockGeo := new(MockGeoIpLookup)
 
@@ -388,7 +388,7 @@ func TestDNSDispatcher_QueryLogging(t *testing.T) {
 		metrics, err := metrics.NewDNSMetrics(cache)
 		assert.NoError(t, err)
 
-		dnsClient, err := NewRoundRobinClient(metrics, 2*time.Second, 1, upstream)
+		dnsClient, err := NewRoundRobinClient(metrics, 2*time.Second, 1, logger, upstream)
 		require.NoError(t, err)
 
 		dispatcher, err := NewDNSDispatcher(cache, metrics, dnsClient, blockList, mockGeo, 1*time.Minute, logger)
@@ -415,7 +415,7 @@ func TestDNSDispatcher_QueryLogging(t *testing.T) {
 		metrics, err := metrics.NewDNSMetrics(cache)
 		assert.NoError(t, err)
 
-		dnsClient, err := NewRoundRobinClient(metrics, 2*time.Second, 1, upstream)
+		dnsClient, err := NewRoundRobinClient(metrics, 2*time.Second, 1, logger, upstream)
 		require.NoError(t, err)
 
 		dispatcher, err := NewDNSDispatcher(cache, metrics, dnsClient, blockList, mockGeo, 1*time.Minute, logger)

--- a/internal/forwarder/round_robin_client.go
+++ b/internal/forwarder/round_robin_client.go
@@ -1,6 +1,8 @@
 package forwarder
 
 import (
+	"log/slog"
+	"net"
 	"sync/atomic"
 	"time"
 
@@ -14,6 +16,7 @@ type RoundRobinClient struct {
 	upstreams []string
 	pools     map[string]*ConnPool
 	counter   uint32
+	logger    *slog.Logger
 }
 
 type pooledConn struct {
@@ -82,6 +85,7 @@ func (p *ConnPool) Exchange(msg *dns.Msg) (*dns.Msg, time.Duration, error) {
 	if err != nil {
 		_ = conn.Close() // discard broken conn
 		if reused {
+			p.metrics.UpstreamFailures.WithLabelValues(p.addr, "pooled_conn_death").Inc()
 			// Retry once with a fresh connection if the pooled one was dead
 			conn, err = p.dial()
 			if err != nil {
@@ -102,7 +106,7 @@ func (p *ConnPool) Exchange(msg *dns.Msg) (*dns.Msg, time.Duration, error) {
 	return resp, rtt, nil
 }
 
-func NewRoundRobinClient(metrics *metrics.DnsMetrics, timeout time.Duration, poolSize int, upstreams ...string) (*RoundRobinClient, error) {
+func NewRoundRobinClient(metrics *metrics.DnsMetrics, timeout time.Duration, poolSize int, logger *slog.Logger, upstreams ...string) (*RoundRobinClient, error) {
 	if len(upstreams) == 0 {
 		return nil, errors.New("no upstream servers configured")
 	}
@@ -119,6 +123,7 @@ func NewRoundRobinClient(metrics *metrics.DnsMetrics, timeout time.Duration, poo
 	return &RoundRobinClient{
 		upstreams: upstreams,
 		pools:     pools,
+		logger:    logger,
 	}, nil
 }
 
@@ -133,9 +138,29 @@ func (r *RoundRobinClient) Exchange(msg *dns.Msg) (*dns.Msg, string, error) {
 		if err == nil {
 			return resp, upstream, nil
 		}
+
+		reason := getFailureReason(err)
+		r.pools[upstream].metrics.UpstreamFailures.WithLabelValues(upstream, reason).Inc()
+		r.logger.Debug("upstream failure", "upstream", upstream, "reason", reason, "error", err)
+
 		lastErr = errors.Wrapf(err, "upstream %s failed", upstream)
 	}
 	return nil, "", errors.Wrap(lastErr, "all upstream servers failed")
+}
+
+func getFailureReason(err error) string {
+	if err == nil {
+		return "none"
+	}
+	var netErr net.Error
+	if errors.As(err, &netErr) && netErr.Timeout() {
+		return "timeout"
+	}
+	var opErr *net.OpError
+	if errors.As(err, &opErr) {
+		return "network_error"
+	}
+	return "other"
 }
 
 func (r *RoundRobinClient) Healthchecks() []checks.Check {

--- a/internal/forwarder/round_robin_client.go
+++ b/internal/forwarder/round_robin_client.go
@@ -17,6 +17,7 @@ type RoundRobinClient struct {
 	pools     map[string]*ConnPool
 	counter   uint32
 	logger    *slog.Logger
+	metrics   *metrics.DnsMetrics
 }
 
 type pooledConn struct {
@@ -124,6 +125,7 @@ func NewRoundRobinClient(metrics *metrics.DnsMetrics, timeout time.Duration, poo
 		upstreams: upstreams,
 		pools:     pools,
 		logger:    logger,
+		metrics:   metrics,
 	}, nil
 }
 
@@ -140,7 +142,7 @@ func (r *RoundRobinClient) Exchange(msg *dns.Msg) (*dns.Msg, string, error) {
 		}
 
 		reason := getFailureReason(err)
-		r.pools[upstream].metrics.UpstreamFailures.WithLabelValues(upstream, reason).Inc()
+		r.metrics.UpstreamFailures.WithLabelValues(upstream, reason).Inc()
 		r.logger.Debug("upstream failure", "upstream", upstream, "reason", reason, "error", err)
 
 		lastErr = errors.Wrapf(err, "upstream %s failed", upstream)

--- a/internal/forwarder/round_robin_client.go
+++ b/internal/forwarder/round_robin_client.go
@@ -86,7 +86,7 @@ func (p *ConnPool) Exchange(msg *dns.Msg) (*dns.Msg, time.Duration, error) {
 	if err != nil {
 		_ = conn.Close() // discard broken conn
 		if reused {
-			p.metrics.UpstreamFailures.WithLabelValues(p.addr, "pooled_conn_death").Inc()
+			p.metrics.PooledConnDeaths.WithLabelValues(p.addr).Inc()
 			// Retry once with a fresh connection if the pooled one was dead
 			conn, err = p.dial()
 			if err != nil {

--- a/internal/metrics/dns_metrics.go
+++ b/internal/metrics/dns_metrics.go
@@ -49,6 +49,7 @@ type DnsMetrics struct {
 	DroppedTelemetry    prometheus.Counter
 	PoolEvictions       *prometheus.CounterVec
 	UpstreamFailures    *prometheus.CounterVec
+	PooledConnDeaths    *prometheus.CounterVec
 }
 
 var latencyBuckets = []float64{
@@ -176,6 +177,11 @@ func NewDNSMetrics(cache Cache) (*DnsMetrics, error) {
 		Help: "Total number of upstream server failures, broken down by server and reason",
 	}, []string{"ip_addr", "reason"})
 
+	pooledConnDeaths := prometheus.NewCounterVec(prometheus.CounterOpts{
+		Name: "dns_pooled_connection_deaths_total",
+		Help: "Total number of pooled connections found to be dead during acquisition, broken down by upstream server",
+	}, []string{"ip_addr"})
+
 	if err := shouldRegister(
 		requestLatency,
 		errorCounts,
@@ -195,6 +201,7 @@ func NewDNSMetrics(cache Cache) (*DnsMetrics, error) {
 		droppedTelemetry,
 		poolEvictions,
 		upstreamFailures,
+		pooledConnDeaths,
 	); err != nil {
 		return nil, errors.Wrap(err, "failed to register DNS metrics")
 	}
@@ -219,6 +226,7 @@ func NewDNSMetrics(cache Cache) (*DnsMetrics, error) {
 		DroppedTelemetry:    droppedTelemetry,
 		PoolEvictions:       poolEvictions,
 		UpstreamFailures:    upstreamFailures,
+		PooledConnDeaths:    pooledConnDeaths,
 	}, nil
 }
 

--- a/internal/metrics/dns_metrics.go
+++ b/internal/metrics/dns_metrics.go
@@ -48,6 +48,7 @@ type DnsMetrics struct {
 	DroppedCacheUpdates prometheus.Counter
 	DroppedTelemetry    prometheus.Counter
 	PoolEvictions       *prometheus.CounterVec
+	UpstreamFailures    *prometheus.CounterVec
 }
 
 var latencyBuckets = []float64{
@@ -170,6 +171,11 @@ func NewDNSMetrics(cache Cache) (*DnsMetrics, error) {
 		Help: "Total number of connections evicted from the pool due to it being full, broken down by upstream server",
 	}, []string{"ip_addr"})
 
+	upstreamFailures := prometheus.NewCounterVec(prometheus.CounterOpts{
+		Name: "dns_upstream_failures_total",
+		Help: "Total number of upstream server failures, broken down by server and reason",
+	}, []string{"ip_addr", "reason"})
+
 	if err := shouldRegister(
 		requestLatency,
 		errorCounts,
@@ -188,6 +194,7 @@ func NewDNSMetrics(cache Cache) (*DnsMetrics, error) {
 		droppedCacheUpdates,
 		droppedTelemetry,
 		poolEvictions,
+		upstreamFailures,
 	); err != nil {
 		return nil, errors.Wrap(err, "failed to register DNS metrics")
 	}
@@ -211,6 +218,7 @@ func NewDNSMetrics(cache Cache) (*DnsMetrics, error) {
 		DroppedCacheUpdates: droppedCacheUpdates,
 		DroppedTelemetry:    droppedTelemetry,
 		PoolEvictions:       poolEvictions,
+		UpstreamFailures:    upstreamFailures,
 	}, nil
 }
 


### PR DESCRIPTION
- Inject `*slog.Logger` into `RoundRobinClient` to enable failure logging.
- Add `dns_upstream_failures_total` Prometheus metric to track upstream failures categorized by server and error type (timeout, network, etc.).
- Update `RoundRobinClient` to record failure reasons upon exchange errors.