### PR TITLE
feat: filter noise in DNS error logging

### DIFF
--- a/internal/forwarder/dispatcher.go
+++ b/internal/forwarder/dispatcher.go
@@ -280,10 +280,11 @@ func (d *DNSDispatcher) resolveUpstream(ctx *RequestContext, unansweredQuestions
 
 	if upstreamResp.Rcode != dns.RcodeSuccess {
 		// Propagate the upstream response Rcode if not successful
-		return upstreamResp.Rcode, nil, errors.NewWithDepthf(0,
+		err := errors.NewWithDepthf(0,
 			"upstream resolver (%s) returned Rcode: %s for query: %s",
 			upstream, dns.RcodeToString[upstreamResp.Rcode], unansweredQuestions[0].Name,
 		)
+		return upstreamResp.Rcode, nil, &RcodeError{Rcode: upstreamResp.Rcode, Err: err}
 	}
 
 	// Group answers by question for efficient lookup
@@ -332,11 +333,14 @@ func (d *DNSDispatcher) isFreshnessSensitive(q *dns.Question) bool {
 var freshnessSensitive = []string{"ocsp", "crl", "pki"}
 
 func (d *DNSDispatcher) reportError(ctx *RequestContext, errorCategory string, err error, additionalFields ...any) {
-	args := append(additionalFields, "category", errorCategory, "error", err)
-	ctx.Logger.Error("DNS error", args...)
+	if ShouldLog(err) {
+		args := append(additionalFields, "category", errorCategory, "error", err)
+		ctx.Logger.Error("DNS error", args...)
+		sentry.CaptureException(err)
+	}
+
 	d.metrics.ErrorCounts.WithLabelValues(errorCategory).Inc()
 	d.metrics.RequestCounts.WithLabelValues("errored", string(ctx.Source)).Inc()
-	sentry.CaptureException(err)
 }
 
 func (d *DNSDispatcher) forwardQuery(ctx *RequestContext, req *dns.Msg) (*dns.Msg, string, error) {

--- a/internal/forwarder/dispatcher_test.go
+++ b/internal/forwarder/dispatcher_test.go
@@ -77,9 +77,11 @@ func (m *MockResponseWriter) TsigTimersOnly(b bool) {
 func (m *MockResponseWriter) Hijack() {
 }
 
-func setupDispatcherTest(t *testing.T, upstream string) (*DNSDispatcher, *MockGeoIpLookup, *blocklist.BlockList, *slog.Logger) {
+func setupDispatcherTest(t *testing.T, upstream string, logger *slog.Logger) (*DNSDispatcher, *MockGeoIpLookup, *blocklist.BlockList, *slog.Logger) {
 	t.Helper()
-	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	if logger == nil {
+		logger = slog.New(slog.NewTextHandler(io.Discard, nil))
+	}
 	blockList := blocklist.NewBlockList([]string{"ads.0xbt.net"}, 0.0001, logger)
 
 	cache := NewDNSCache(100, logger)
@@ -128,7 +130,7 @@ func TestDNSDispatcher_HandleDNSRequest_MixedBlockedAndUpstream(t *testing.T) {
 		assert.NoError(t, err)
 	}()
 
-	dispatcher, _, _, _ := setupDispatcherTest(t, upstream)
+	dispatcher, _, _, _ := setupDispatcherTest(t, upstream, nil)
 
 	req := new(dns.Msg)
 	req.Question = []dns.Question{
@@ -168,7 +170,7 @@ func TestDNSDispatcher_HandleDNSRequest_Allowed(t *testing.T) {
 		assert.NoError(t, err)
 	}()
 
-	dispatcher, _, _, _ := setupDispatcherTest(t, upstream)
+	dispatcher, _, _, _ := setupDispatcherTest(t, upstream, nil)
 
 	req := new(dns.Msg)
 	req.SetQuestion("google.com.", dns.TypeA)
@@ -195,7 +197,7 @@ func TestDNSDispatcher_HandleDNSRequest_Blocked(t *testing.T) {
 		assert.NoError(t, err)
 	}()
 
-	dispatcher, _, _, _ := setupDispatcherTest(t, upstream)
+	dispatcher, _, _, _ := setupDispatcherTest(t, upstream, nil)
 
 	req := new(dns.Msg)
 	req.SetQuestion("ads.0xbt.net.", dns.TypeA)
@@ -225,7 +227,7 @@ func TestDNSDispatcher_HandleDNSRequest_MultipleQuestions(t *testing.T) {
 		assert.NoError(t, err)
 	}()
 
-	dispatcher, _, _, _ := setupDispatcherTest(t, upstream)
+	dispatcher, _, _, _ := setupDispatcherTest(t, upstream, nil)
 
 	req := new(dns.Msg)
 	req.Question = []dns.Question{
@@ -267,7 +269,7 @@ func TestDNSDispatcher_HandleDNSRequest_CacheHit(t *testing.T) {
 		assert.NoError(t, err)
 	}()
 
-	dispatcher, _, _, _ := setupDispatcherTest(t, upstream)
+	dispatcher, _, _, _ := setupDispatcherTest(t, upstream, nil)
 
 	req := new(dns.Msg)
 	req.SetQuestion("example.com.", dns.TypeA)
@@ -310,7 +312,7 @@ func TestDNSDispatcher_ResolveUpstream_BadRCode(t *testing.T) {
 		assert.NoError(t, err)
 	}()
 
-	dispatcher, _, _, _ := setupDispatcherTest(t, upstream)
+	dispatcher, _, _, _ := setupDispatcherTest(t, upstream, nil)
 
 	req := new(dns.Msg)
 	req.SetQuestion("google.com.", dns.TypeA)
@@ -354,7 +356,7 @@ func TestDNSDispatcher_HandleDNSRequest_DNSSD_NXDOMAIN(t *testing.T) {
 		assert.NoError(t, err)
 	}()
 
-	dispatcher, _, _, _ := setupDispatcherTest(t, upstream)
+	dispatcher, _, _, _ := setupDispatcherTest(t, upstream, nil)
 
 	req := new(dns.Msg)
 	req.SetQuestion("db._dns-sd._udp.0.68.168.192.in-addr.arpa.", dns.TypePTR)
@@ -373,7 +375,6 @@ func TestDNSDispatcher_HandleDNSRequest_UpstreamNXDOMAIN_NoLogError(t *testing.T
 	var logBuf bytes.Buffer
 	logger := slog.New(slog.NewTextHandler(&logBuf, &slog.HandlerOptions{Level: slog.LevelError}))
 
-	blockList := blocklist.NewBlockList([]string{}, 0.0001, logger)
 	server, upstream := startLocalDNS(t, func(w dns.ResponseWriter, r *dns.Msg) {
 		m := new(dns.Msg)
 		m.SetReply(r)
@@ -384,19 +385,7 @@ func TestDNSDispatcher_HandleDNSRequest_UpstreamNXDOMAIN_NoLogError(t *testing.T
 		_ = server.Shutdown()
 	}()
 
-	cache := NewDNSCache(100, logger)
-	metrics, err := metrics.NewDNSMetrics(cache)
-	require.NoError(t, err)
-
-	dnsClient, err := NewRoundRobinClient(metrics, 2*time.Second, 1, logger, upstream)
-	require.NoError(t, err)
-
-	mockGeo := new(MockGeoIpLookup)
-	mockGeo.On("GetAll", mock.Anything).Return(ip2location.IP2Locationrecord{}, nil)
-
-	dispatcher, err := NewDNSDispatcher(cache, metrics, dnsClient, blockList, mockGeo, 1*time.Minute, logger)
-	require.NoError(t, err)
-	t.Cleanup(dispatcher.Close)
+	dispatcher, _, _, _ := setupDispatcherTest(t, upstream, logger)
 
 	req := new(dns.Msg)
 	req.SetQuestion("nonexistent.example.com.", dns.TypeA)
@@ -414,11 +403,42 @@ func TestDNSDispatcher_HandleDNSRequest_UpstreamNXDOMAIN_NoLogError(t *testing.T
 	assert.Empty(t, logBuf.String(), "should not log NXDOMAIN as ERROR")
 }
 
+func TestDNSDispatcher_HandleDNSRequest_UpstreamNOTIMP_NoLogError(t *testing.T) {
+	var logBuf bytes.Buffer
+	logger := slog.New(slog.NewTextHandler(&logBuf, &slog.HandlerOptions{Level: slog.LevelError}))
+
+	server, upstream := startLocalDNS(t, func(w dns.ResponseWriter, r *dns.Msg) {
+		m := new(dns.Msg)
+		m.SetReply(r)
+		m.SetRcode(r, dns.RcodeNotImplemented) // NOTIMP
+		_ = w.WriteMsg(m)
+	})
+	defer func() {
+		_ = server.Shutdown()
+	}()
+
+	dispatcher, _, _, _ := setupDispatcherTest(t, upstream, logger)
+
+	req := new(dns.Msg)
+	req.SetQuestion("notimp.example.com.", dns.TypeA)
+
+	writer := new(MockResponseWriter)
+	writer.On("WriteMsg", mock.Anything).Return(nil)
+
+	// Call the method under test
+	dispatcher.HandleDNSRequest("test")(writer, req)
+
+	assert.NotNil(t, writer.WrittenMsg)
+	assert.Equal(t, dns.RcodeNotImplemented, writer.WrittenMsg.Rcode)
+
+	// Verify that no ERROR log was written
+	assert.Empty(t, logBuf.String(), "should not log NOTIMP as ERROR")
+}
+
 func TestDNSDispatcher_HandleDNSRequest_UpstreamSERVFAIL_LogError(t *testing.T) {
 	var logBuf bytes.Buffer
 	logger := slog.New(slog.NewTextHandler(&logBuf, &slog.HandlerOptions{Level: slog.LevelError}))
 
-	blockList := blocklist.NewBlockList([]string{}, 0.0001, logger)
 	server, upstream := startLocalDNS(t, func(w dns.ResponseWriter, r *dns.Msg) {
 		m := new(dns.Msg)
 		m.SetReply(r)
@@ -429,19 +449,7 @@ func TestDNSDispatcher_HandleDNSRequest_UpstreamSERVFAIL_LogError(t *testing.T) 
 		_ = server.Shutdown()
 	}()
 
-	cache := NewDNSCache(100, logger)
-	metrics, err := metrics.NewDNSMetrics(cache)
-	require.NoError(t, err)
-
-	dnsClient, err := NewRoundRobinClient(metrics, 2*time.Second, 1, logger, upstream)
-	require.NoError(t, err)
-
-	mockGeo := new(MockGeoIpLookup)
-	mockGeo.On("GetAll", mock.Anything).Return(ip2location.IP2Locationrecord{}, nil)
-
-	dispatcher, err := NewDNSDispatcher(cache, metrics, dnsClient, blockList, mockGeo, 1*time.Minute, logger)
-	require.NoError(t, err)
-	t.Cleanup(dispatcher.Close)
+	dispatcher, _, _, _ := setupDispatcherTest(t, upstream, logger)
 
 	req := new(dns.Msg)
 	req.SetQuestion("error.example.com.", dns.TypeA)
@@ -564,7 +572,7 @@ func deadline(t *testing.T, timeout time.Duration) time.Time {
 }
 
 func TestDNSDispatcher_ReservedTLDs(t *testing.T) {
-	dispatcher, _, _, _ := setupDispatcherTest(t, "127.0.0.1:53")
+	dispatcher, _, _, _ := setupDispatcherTest(t, "127.0.0.1:53", nil)
 
 	tests := []struct {
 		name     string

--- a/internal/forwarder/dispatcher_test.go
+++ b/internal/forwarder/dispatcher_test.go
@@ -369,69 +369,94 @@ func TestDNSDispatcher_HandleDNSRequest_DNSSD_NXDOMAIN(t *testing.T) {
 	assert.NotNil(t, writer.WrittenMsg)
 	assert.Equal(t, dns.RcodeNameError, writer.WrittenMsg.Rcode, "should return NXDOMAIN")
 }
-func TestDNSDispatcher_QueryLogging(t *testing.T) {
+func TestDNSDispatcher_HandleDNSRequest_UpstreamNXDOMAIN_NoLogError(t *testing.T) {
 	var logBuf bytes.Buffer
+	logger := slog.New(slog.NewTextHandler(&logBuf, &slog.HandlerOptions{Level: slog.LevelError}))
 
-	blockList := blocklist.NewBlockList([]string{"ads.0xbt.net"}, 0.0001, slog.New(slog.NewTextHandler(io.Discard, nil)))
-	server, upstream := startLocalDNS(t, dnsRecord("google.com.", dns.TypeA, []byte{142, 251, 29, 101}))
+	blockList := blocklist.NewBlockList([]string{}, 0.0001, logger)
+	server, upstream := startLocalDNS(t, func(w dns.ResponseWriter, r *dns.Msg) {
+		m := new(dns.Msg)
+		m.SetReply(r)
+		m.SetRcode(r, dns.RcodeNameError) // NXDOMAIN
+		_ = w.WriteMsg(m)
+	})
 	defer func() {
 		_ = server.Shutdown()
 	}()
 
-	t.Run("Logging at INFO level (should not contain debug logs)", func(t *testing.T) {
-		logBuf.Reset()
-		logger := slog.New(slog.NewTextHandler(&logBuf, &slog.HandlerOptions{Level: slog.LevelInfo}))
-		mockGeo := new(MockGeoIpLookup)
-		mockGeo.On("GetAll", mock.Anything).Return(ip2location.IP2Locationrecord{}, nil)
+	cache := NewDNSCache(100, logger)
+	metrics, err := metrics.NewDNSMetrics(cache)
+	require.NoError(t, err)
 
-		cache := NewDNSCache(100, logger)
-		metrics, err := metrics.NewDNSMetrics(cache)
-		assert.NoError(t, err)
+	dnsClient, err := NewRoundRobinClient(metrics, 2*time.Second, 1, upstream)
+	require.NoError(t, err)
 
-		dnsClient, err := NewRoundRobinClient(metrics, 2*time.Second, 1, upstream)
-		require.NoError(t, err)
+	mockGeo := new(MockGeoIpLookup)
+	mockGeo.On("GetAll", mock.Anything).Return(ip2location.IP2Locationrecord{}, nil)
 
-		dispatcher, err := NewDNSDispatcher(cache, metrics, dnsClient, blockList, mockGeo, 1*time.Minute, logger)
-		require.NoError(t, err)
-		t.Cleanup(dispatcher.Close)
+	dispatcher, err := NewDNSDispatcher(cache, metrics, dnsClient, blockList, mockGeo, 1*time.Minute, logger)
+	require.NoError(t, err)
+	t.Cleanup(dispatcher.Close)
 
-		req := new(dns.Msg)
-		req.SetQuestion("google.com.", dns.TypeA)
-		writer := new(MockResponseWriter)
-		writer.On("WriteMsg", mock.Anything).Return(nil)
+	req := new(dns.Msg)
+	req.SetQuestion("nonexistent.example.com.", dns.TypeA)
 
-		dispatcher.HandleDNSRequest("test")(writer, req)
+	writer := new(MockResponseWriter)
+	writer.On("WriteMsg", mock.Anything).Return(nil)
 
-		assert.NotContains(t, logBuf.String(), "Query received")
+	// Call the method under test
+	dispatcher.HandleDNSRequest("test")(writer, req)
+
+	assert.NotNil(t, writer.WrittenMsg)
+	assert.Equal(t, dns.RcodeNameError, writer.WrittenMsg.Rcode)
+
+	// Verify that no ERROR log was written
+	assert.Empty(t, logBuf.String(), "should not log NXDOMAIN as ERROR")
+}
+
+func TestDNSDispatcher_HandleDNSRequest_UpstreamSERVFAIL_LogError(t *testing.T) {
+	var logBuf bytes.Buffer
+	logger := slog.New(slog.NewTextHandler(&logBuf, &slog.HandlerOptions{Level: slog.LevelError}))
+
+	blockList := blocklist.NewBlockList([]string{}, 0.0001, logger)
+	server, upstream := startLocalDNS(t, func(w dns.ResponseWriter, r *dns.Msg) {
+		m := new(dns.Msg)
+		m.SetReply(r)
+		m.SetRcode(r, dns.RcodeServerFailure) // SERVFAIL
+		_ = w.WriteMsg(m)
 	})
+	defer func() {
+		_ = server.Shutdown()
+	}()
 
-	t.Run("Logging at DEBUG level", func(t *testing.T) {
-		logBuf.Reset()
-		logger := slog.New(slog.NewTextHandler(&logBuf, &slog.HandlerOptions{Level: slog.LevelDebug}))
-		mockGeo := new(MockGeoIpLookup)
-		mockGeo.On("GetAll", mock.Anything).Return(ip2location.IP2Locationrecord{}, nil)
+	cache := NewDNSCache(100, logger)
+	metrics, err := metrics.NewDNSMetrics(cache)
+	require.NoError(t, err)
 
-		cache := NewDNSCache(100, logger)
-		metrics, err := metrics.NewDNSMetrics(cache)
-		assert.NoError(t, err)
+	dnsClient, err := NewRoundRobinClient(metrics, 2*time.Second, 1, upstream)
+	require.NoError(t, err)
 
-		dnsClient, err := NewRoundRobinClient(metrics, 2*time.Second, 1, upstream)
-		require.NoError(t, err)
+	mockGeo := new(MockGeoIpLookup)
+	mockGeo.On("GetAll", mock.Anything).Return(ip2location.IP2Locationrecord{}, nil)
 
-		dispatcher, err := NewDNSDispatcher(cache, metrics, dnsClient, blockList, mockGeo, 1*time.Minute, logger)
-		require.NoError(t, err)
-		t.Cleanup(dispatcher.Close)
+	dispatcher, err := NewDNSDispatcher(cache, metrics, dnsClient, blockList, mockGeo, 1*time.Minute, logger)
+	require.NoError(t, err)
+	t.Cleanup(dispatcher.Close)
 
-		req := new(dns.Msg)
-		req.SetQuestion("google.com.", dns.TypeA)
-		writer := new(MockResponseWriter)
-		writer.On("WriteMsg", mock.Anything).Return(nil)
+	req := new(dns.Msg)
+	req.SetQuestion("error.example.com.", dns.TypeA)
 
-		dispatcher.HandleDNSRequest("test")(writer, req)
+	writer := new(MockResponseWriter)
+	writer.On("WriteMsg", mock.Anything).Return(nil)
 
-		assert.Contains(t, logBuf.String(), "Query received")
-		assert.Contains(t, logBuf.String(), "google.com.")
-	})
+	// Call the method under test
+	dispatcher.HandleDNSRequest("test")(writer, req)
+
+	assert.NotNil(t, writer.WrittenMsg)
+	assert.Equal(t, dns.RcodeServerFailure, writer.WrittenMsg.Rcode)
+
+	// Verify that an ERROR log was written
+	assert.Contains(t, logBuf.String(), "level=ERROR", "should log SERVFAIL as ERROR")
 }
 
 func dnsRecord(addr string, rrtype uint16, ip []byte) dns.HandlerFunc {

--- a/internal/forwarder/errors.go
+++ b/internal/forwarder/errors.go
@@ -1,0 +1,32 @@
+package forwarder
+
+import (
+	"errors"
+
+	"github.com/miekg/dns"
+)
+
+type RcodeError struct {
+	Rcode int
+	Err   error
+}
+
+func (e *RcodeError) Error() string {
+	return e.Err.Error()
+}
+
+func (e *RcodeError) Unwrap() error {
+	return e.Err
+}
+
+func (e *RcodeError) ShouldLog() bool {
+	return e.Rcode != dns.RcodeNameError
+}
+
+func ShouldLog(err error) bool {
+	var loggable interface{ ShouldLog() bool }
+	if errors.As(err, &loggable) {
+		return loggable.ShouldLog()
+	}
+	return true
+}

--- a/internal/forwarder/errors.go
+++ b/internal/forwarder/errors.go
@@ -23,7 +23,7 @@ func (e *RcodeError) Unwrap() error {
 }
 
 func (e *RcodeError) ShouldLog() bool {
-	return e.Rcode != dns.RcodeNameError
+	return e.Rcode != dns.RcodeNameError && e.Rcode != dns.RcodeNotImplemented
 }
 
 func ShouldLog(err error) bool {

--- a/internal/forwarder/errors.go
+++ b/internal/forwarder/errors.go
@@ -24,6 +24,9 @@ func (e *RcodeError) ShouldLog() bool {
 }
 
 func ShouldLog(err error) bool {
+	if err == nil {
+		return false
+	}
 	var loggable interface{ ShouldLog() bool }
 	if errors.As(err, &loggable) {
 		return loggable.ShouldLog()

--- a/internal/forwarder/errors.go
+++ b/internal/forwarder/errors.go
@@ -12,7 +12,10 @@ type RcodeError struct {
 }
 
 func (e *RcodeError) Error() string {
-	return e.Err.Error()
+	if e.Err != nil {
+		return e.Err.Error()
+	}
+	return "dns rcode error: " + dns.RcodeToString[e.Rcode]
 }
 
 func (e *RcodeError) Unwrap() error {


### PR DESCRIPTION
- Introduce `RcodeError` to categorize DNS errors.
- Update `reportError` to check `ShouldLog` before logging and sending to Sentry.
- Suppress logs and Sentry alerts for `NXDOMAIN` errors.
- Add tests to verify error logging behavior for `NXDOMAIN` vs `SERVFAIL`.