### PR TITLE
fix: buffer metrics collection in RequestContext

### DIFF
--- a/internal/app.go
+++ b/internal/app.go
@@ -101,6 +101,9 @@ func (app *App) RunServer() error {
 		return errors.Wrap(err, "failed to open geoblock database")
 	}
 
+	// Wrap GeoIpLookup to satisfy the metrics.GeoIpLookup interface
+	metricsGeoIpLookup := geoIpLookupWrapper{geoIpLookup}
+
 	app.Logger.Info("Creating IP2Location updater cron job", "schedule", app.CronSchedule.IP2Location)
 	if _, err = crontab.AddJob(app.CronSchedule.IP2Location, geoblock.NewIp2LocationUpdaterCronJob(app.Logger, "DB1LITEBIN", app.DataDir, geoIpLookup)); err != nil {
 		return errors.Wrap(err, "failed to create IP2Location updater cron job")
@@ -160,7 +163,7 @@ func (app *App) RunServer() error {
 	}
 
 	cache := forwarder.NewDNSCache(app.MaxCacheSize, app.Logger)
-	metrics, err := metrics.NewDNSMetrics(cache)
+	metrics, err := metrics.NewDNSMetrics(cache, metricsGeoIpLookup)
 	if err != nil {
 		return errors.Wrap(err, "failed to initialize metrics")
 	}
@@ -174,7 +177,7 @@ func (app *App) RunServer() error {
 		return errors.Wrap(err, "failed to initialize HTTP server")
 	}
 
-	dispatcher, err := forwarder.NewDNSDispatcher(cache, metrics, dnsClient, blockList, geoIpLookup, app.CacheTtlFloor, app.Logger)
+	dispatcher, err := forwarder.NewDNSDispatcher(cache, metrics, dnsClient, blockList, app.CacheTtlFloor, app.Logger)
 	if err != nil {
 		return errors.Wrap(err, "failed to create dispatcher")
 	}
@@ -396,4 +399,16 @@ func newStructuredLoggingConfig() *sloggin.Config {
 	config.Filters = append(config.Filters, sloggin.IgnorePath("/healthz", "/metrics"))
 
 	return &config
+}
+
+type geoIpLookupWrapper struct {
+	lookup geoblock.GeoIpLookup
+}
+
+func (w geoIpLookupWrapper) GetAll(ipAddress string) (string, error) {
+	record, err := w.lookup.GetAll(ipAddress)
+	if err != nil {
+		return "", err
+	}
+	return record.Country_short, nil
 }

--- a/internal/app.go
+++ b/internal/app.go
@@ -101,9 +101,6 @@ func (app *App) RunServer() error {
 		return errors.Wrap(err, "failed to open geoblock database")
 	}
 
-	// Wrap GeoIpLookup to satisfy the metrics.GeoIpLookup interface
-	metricsGeoIpLookup := geoIpLookupWrapper{geoIpLookup}
-
 	app.Logger.Info("Creating IP2Location updater cron job", "schedule", app.CronSchedule.IP2Location)
 	if _, err = crontab.AddJob(app.CronSchedule.IP2Location, geoblock.NewIp2LocationUpdaterCronJob(app.Logger, "DB1LITEBIN", app.DataDir, geoIpLookup)); err != nil {
 		return errors.Wrap(err, "failed to create IP2Location updater cron job")
@@ -163,7 +160,7 @@ func (app *App) RunServer() error {
 	}
 
 	cache := forwarder.NewDNSCache(app.MaxCacheSize, app.Logger)
-	metrics, err := metrics.NewDNSMetrics(cache, metricsGeoIpLookup)
+	metrics, err := metrics.NewDNSMetrics(cache, geoIpLookup)
 	if err != nil {
 		return errors.Wrap(err, "failed to initialize metrics")
 	}
@@ -399,16 +396,4 @@ func newStructuredLoggingConfig() *sloggin.Config {
 	config.Filters = append(config.Filters, sloggin.IgnorePath("/healthz", "/metrics"))
 
 	return &config
-}
-
-type geoIpLookupWrapper struct {
-	lookup geoblock.GeoIpLookup
-}
-
-func (w geoIpLookupWrapper) GetAll(ipAddress string) (string, error) {
-	record, err := w.lookup.GetAll(ipAddress)
-	if err != nil {
-		return "", err
-	}
-	return record.Country_short, nil
 }

--- a/internal/forwarder/dispatcher.go
+++ b/internal/forwarder/dispatcher.go
@@ -1,7 +1,6 @@
 package forwarder
 
 import (
-	"fmt"
 	"log/slog"
 	"net"
 	"strings"
@@ -43,15 +42,7 @@ type RequestContext struct {
 	IpAddr    string
 
 	// Metrics collection
-	blockedDomains  []string
-	domains         []string
-	queryCounts     []queryCountInfo
-	upstreamTTL     *upstreamTTLInfo
-	errorCategory   string
-	requestTypes    []string
-	upstream        string
-	upstreamLatency float64
-	rcode           string
+	telemetry *metrics.TelemetryData
 }
 
 type TelemetryEvent struct {
@@ -132,6 +123,7 @@ func (d *DNSDispatcher) HandleDNSRequest(source DNSSource) DispatcherFunc {
 			Source:    source,
 			StartTime: time.Now(),
 			IpAddr:    ipAddr,
+			telemetry: &metrics.TelemetryData{},
 		}
 
 		defer func() {
@@ -197,7 +189,18 @@ func (d *DNSDispatcher) telemetryWorker() {
 			if !ok {
 				return
 			}
-			d.recordTelemetry(event.ctx, event.latency)
+			
+			countryCode := ""
+			if event.ctx.IpAddr != "unknown" && event.ctx.IpAddr != "" {
+				loc, err := d.geoIpLookup.GetAll(event.ctx.IpAddr)
+				if err != nil {
+					event.ctx.Logger.Warn("failed to get geolocation for client IP", "error", err)
+				} else {
+					countryCode = loc.Country_short
+				}
+			}
+
+			d.metrics.RecordTelemetry(event.ctx.telemetry, event.latency, string(event.ctx.Source), event.ctx.IpAddr, countryCode)
 		case <-d.done:
 			return
 		}
@@ -205,45 +208,7 @@ func (d *DNSDispatcher) telemetryWorker() {
 }
 
 func (d *DNSDispatcher) recordTelemetry(ctx *RequestContext, latency float64) {
-	d.metrics.RequestLatency.Observe(latency)
-	d.metrics.RequestCounts.WithLabelValues("total", string(ctx.Source)).Inc()
-
-	if ctx.IpAddr != "unknown" {
-		d.metrics.TopClients.Add(ctx.IpAddr)
-		d.metrics.UniqueClients.Insert([]byte(ctx.IpAddr))
-
-		loc, err := d.geoIpLookup.GetAll(ctx.IpAddr)
-		if err != nil {
-			ctx.Logger.Warn("failed to get geolocation for client IP", "error", err)
-		} else {
-			d.metrics.CountryCounts.WithLabelValues(loc.Country_short).Inc()
-		}
-	}
-
-	for _, qc := range ctx.queryCounts {
-		d.metrics.QueryCounts.WithLabelValues(qc.queryType, fmt.Sprintf("%t", qc.blocked)).Inc()
-	}
-	for _, domain := range ctx.blockedDomains {
-		d.metrics.TopBlockedDomains.Add(domain)
-	}
-	for _, domain := range ctx.domains {
-		d.metrics.TopDomains.Add(domain)
-	}
-	if ctx.upstreamTTL != nil {
-		d.metrics.UpstreamTTLs.WithLabelValues(ctx.upstreamTTL.queryType).Observe(ctx.upstreamTTL.ttl)
-	}
-	if ctx.errorCategory != "" {
-		d.metrics.ErrorCounts.WithLabelValues(ctx.errorCategory).Inc()
-	}
-	for _, rt := range ctx.requestTypes {
-		d.metrics.RequestCounts.WithLabelValues(rt, string(ctx.Source)).Inc()
-	}
-	if ctx.upstream != "" {
-		d.metrics.UpstreamLatency.WithLabelValues(ctx.upstream).Observe(ctx.upstreamLatency)
-	}
-	if ctx.rcode != "" {
-		d.metrics.ReplyCounts.WithLabelValues(ctx.rcode).Inc()
-	}
+	// This method is no longer used.
 }
 
 func (d *DNSDispatcher) processQuestion(ctx *RequestContext, q *dns.Question) ([]dns.RR, int, error) {
@@ -260,8 +225,8 @@ func (d *DNSDispatcher) processQuestion(ctx *RequestContext, q *dns.Question) ([
 
 	if isBlocked {
 		ctx.Logger.Debug("Domain blocked", "name", q.Name)
-		ctx.blockedDomains = append(ctx.blockedDomains, q.Name)
-		ctx.queryCounts = append(ctx.queryCounts, queryCountInfo{queryType, true})
+		ctx.telemetry.BlockedDomains = append(ctx.telemetry.BlockedDomains, q.Name)
+		ctx.telemetry.QueryCounts = append(ctx.telemetry.QueryCounts, metrics.QueryCountInfo{QueryType: queryType, Blocked: true})
 
 		soa := &dns.SOA{
 			Hdr: dns.RR_Header{
@@ -301,12 +266,12 @@ func (d *DNSDispatcher) processQuestion(ctx *RequestContext, q *dns.Question) ([
 
 	if isDNSSDQuery(q.Name) {
 		ctx.Logger.Debug("Short-circuiting DNS-SD query", "name", q.Name)
-		ctx.queryCounts = append(ctx.queryCounts, queryCountInfo{queryType, false})
+		ctx.telemetry.QueryCounts = append(ctx.telemetry.QueryCounts, metrics.QueryCountInfo{QueryType: queryType, Blocked: false})
 		return nil, dns.RcodeNameError, nil
 	}
 
-	ctx.domains = append(ctx.domains, q.Name)
-	ctx.queryCounts = append(ctx.queryCounts, queryCountInfo{queryType, false})
+	ctx.telemetry.Domains = append(ctx.telemetry.Domains, q.Name)
+	ctx.telemetry.QueryCounts = append(ctx.telemetry.QueryCounts, metrics.QueryCountInfo{QueryType: queryType, Blocked: false})
 	if cachedRRs, ok := d.cache.Get(getCacheKey(q)); ok {
 		return cachedRRs, dns.RcodeSuccess, nil
 	}
@@ -353,7 +318,7 @@ func (d *DNSDispatcher) resolveUpstream(ctx *RequestContext, unansweredQuestions
 			}
 
 			d.cache.Set(key, answersForQuestion, effectiveTTL)
-			ctx.upstreamTTL = &upstreamTTLInfo{getQueryType(&q), float64(upstreamTTL)}
+			ctx.telemetry.UpstreamTTL = &metrics.UpstreamTTLInfo{QueryType: getQueryType(&q), TTL: float64(upstreamTTL)}
 		}
 	}
 
@@ -386,24 +351,23 @@ func (d *DNSDispatcher) reportError(ctx *RequestContext, errorCategory string, e
 		sentry.CaptureException(err)
 	}
 
-	d.metrics.ErrorCounts.WithLabelValues(errorCategory).Inc()
-	ctx.errorCategory = errorCategory
-	ctx.requestTypes = append(ctx.requestTypes, "errored")
+	ctx.telemetry.ErrorCategory = errorCategory
+	ctx.telemetry.RequestTypes = append(ctx.telemetry.RequestTypes, "errored")
 }
 
 func (d *DNSDispatcher) forwardQuery(ctx *RequestContext, req *dns.Msg) (*dns.Msg, string, error) {
 	startTime := time.Now()
-	ctx.requestTypes = append(ctx.requestTypes, "forwarded")
+	ctx.telemetry.RequestTypes = append(ctx.telemetry.RequestTypes, "forwarded")
 	in, upstream, err := d.dnsClient.Exchange(req)
 
 	duration := time.Since(startTime).Seconds()
-	ctx.upstream = upstream
-	ctx.upstreamLatency = duration
+	ctx.telemetry.Upstream = upstream
+	ctx.telemetry.UpstreamLatency = duration
 	return in, upstream, err
 }
 
 func (d *DNSDispatcher) sendResponse(ctx *RequestContext, writer dns.ResponseWriter, msg *dns.Msg) {
-	ctx.rcode = dns.RcodeToString[msg.Rcode]
+	ctx.telemetry.Rcode = dns.RcodeToString[msg.Rcode]
 	if err := writer.WriteMsg(msg); err != nil {
 		d.reportError(ctx, "response", err)
 		return

--- a/internal/forwarder/dispatcher.go
+++ b/internal/forwarder/dispatcher.go
@@ -24,16 +24,6 @@ const (
 	SourceDoT DNSSource = "DoT"
 )
 
-type queryCountInfo struct {
-	queryType string
-	blocked   bool
-}
-
-type upstreamTTLInfo struct {
-	queryType string
-	ttl       float64
-}
-
 type RequestContext struct {
 	Logger    *slog.Logger
 	Source    DNSSource

--- a/internal/forwarder/dispatcher.go
+++ b/internal/forwarder/dispatcher.go
@@ -1,6 +1,7 @@
 package forwarder
 
 import (
+	"fmt"
 	"log/slog"
 	"net"
 	"strings"
@@ -25,11 +26,32 @@ const (
 	SourceDoT DNSSource = "DoT"
 )
 
+type queryCountInfo struct {
+	queryType string
+	blocked   bool
+}
+
+type upstreamTTLInfo struct {
+	queryType string
+	ttl       float64
+}
+
 type RequestContext struct {
 	Logger    *slog.Logger
 	Source    DNSSource
 	StartTime time.Time
 	IpAddr    string
+
+	// Metrics collection
+	blockedDomains  []string
+	domains         []string
+	queryCounts     []queryCountInfo
+	upstreamTTL     *upstreamTTLInfo
+	errorCategory   string
+	requestTypes    []string
+	upstream        string
+	upstreamLatency float64
+	rcode           string
 }
 
 type TelemetryEvent struct {
@@ -197,6 +219,31 @@ func (d *DNSDispatcher) recordTelemetry(ctx *RequestContext, latency float64) {
 			d.metrics.CountryCounts.WithLabelValues(loc.Country_short).Inc()
 		}
 	}
+
+	for _, qc := range ctx.queryCounts {
+		d.metrics.QueryCounts.WithLabelValues(qc.queryType, fmt.Sprintf("%t", qc.blocked)).Inc()
+	}
+	for _, domain := range ctx.blockedDomains {
+		d.metrics.TopBlockedDomains.Add(domain)
+	}
+	for _, domain := range ctx.domains {
+		d.metrics.TopDomains.Add(domain)
+	}
+	if ctx.upstreamTTL != nil {
+		d.metrics.UpstreamTTLs.WithLabelValues(ctx.upstreamTTL.queryType).Observe(ctx.upstreamTTL.ttl)
+	}
+	if ctx.errorCategory != "" {
+		d.metrics.ErrorCounts.WithLabelValues(ctx.errorCategory).Inc()
+	}
+	for _, rt := range ctx.requestTypes {
+		d.metrics.RequestCounts.WithLabelValues(rt, string(ctx.Source)).Inc()
+	}
+	if ctx.upstream != "" {
+		d.metrics.UpstreamLatency.WithLabelValues(ctx.upstream).Observe(ctx.upstreamLatency)
+	}
+	if ctx.rcode != "" {
+		d.metrics.ReplyCounts.WithLabelValues(ctx.rcode).Inc()
+	}
 }
 
 func (d *DNSDispatcher) processQuestion(ctx *RequestContext, q *dns.Question) ([]dns.RR, int, error) {
@@ -213,8 +260,8 @@ func (d *DNSDispatcher) processQuestion(ctx *RequestContext, q *dns.Question) ([
 
 	if isBlocked {
 		ctx.Logger.Debug("Domain blocked", "name", q.Name)
-		d.metrics.TopBlockedDomains.Add(q.Name)
-		d.metrics.QueryCounts.WithLabelValues(queryType, "true").Inc()
+		ctx.blockedDomains = append(ctx.blockedDomains, q.Name)
+		ctx.queryCounts = append(ctx.queryCounts, queryCountInfo{queryType, true})
 
 		soa := &dns.SOA{
 			Hdr: dns.RR_Header{
@@ -254,12 +301,12 @@ func (d *DNSDispatcher) processQuestion(ctx *RequestContext, q *dns.Question) ([
 
 	if isDNSSDQuery(q.Name) {
 		ctx.Logger.Debug("Short-circuiting DNS-SD query", "name", q.Name)
-		d.metrics.QueryCounts.WithLabelValues(queryType, "false").Inc()
+		ctx.queryCounts = append(ctx.queryCounts, queryCountInfo{queryType, false})
 		return nil, dns.RcodeNameError, nil
 	}
 
-	d.metrics.TopDomains.Add(q.Name)
-	d.metrics.QueryCounts.WithLabelValues(queryType, "false").Inc()
+	ctx.domains = append(ctx.domains, q.Name)
+	ctx.queryCounts = append(ctx.queryCounts, queryCountInfo{queryType, false})
 	if cachedRRs, ok := d.cache.Get(getCacheKey(q)); ok {
 		return cachedRRs, dns.RcodeSuccess, nil
 	}
@@ -306,7 +353,7 @@ func (d *DNSDispatcher) resolveUpstream(ctx *RequestContext, unansweredQuestions
 			}
 
 			d.cache.Set(key, answersForQuestion, effectiveTTL)
-			d.metrics.UpstreamTTLs.WithLabelValues(getQueryType(&q)).Observe(float64(upstreamTTL))
+			ctx.upstreamTTL = &upstreamTTLInfo{getQueryType(&q), float64(upstreamTTL)}
 		}
 	}
 
@@ -340,21 +387,23 @@ func (d *DNSDispatcher) reportError(ctx *RequestContext, errorCategory string, e
 	}
 
 	d.metrics.ErrorCounts.WithLabelValues(errorCategory).Inc()
-	d.metrics.RequestCounts.WithLabelValues("errored", string(ctx.Source)).Inc()
+	ctx.errorCategory = errorCategory
+	ctx.requestTypes = append(ctx.requestTypes, "errored")
 }
 
 func (d *DNSDispatcher) forwardQuery(ctx *RequestContext, req *dns.Msg) (*dns.Msg, string, error) {
 	startTime := time.Now()
-	d.metrics.RequestCounts.WithLabelValues("forwarded", string(ctx.Source)).Inc()
+	ctx.requestTypes = append(ctx.requestTypes, "forwarded")
 	in, upstream, err := d.dnsClient.Exchange(req)
 
 	duration := time.Since(startTime).Seconds()
-	d.metrics.UpstreamLatency.WithLabelValues(upstream).Observe(duration)
+	ctx.upstream = upstream
+	ctx.upstreamLatency = duration
 	return in, upstream, err
 }
 
 func (d *DNSDispatcher) sendResponse(ctx *RequestContext, writer dns.ResponseWriter, msg *dns.Msg) {
-	d.metrics.ReplyCounts.WithLabelValues(dns.RcodeToString[msg.Rcode]).Inc()
+	ctx.rcode = dns.RcodeToString[msg.Rcode]
 	if err := writer.WriteMsg(msg); err != nil {
 		d.reportError(ctx, "response", err)
 		return

--- a/internal/forwarder/dispatcher.go
+++ b/internal/forwarder/dispatcher.go
@@ -25,18 +25,8 @@ const (
 )
 
 type RequestContext struct {
-	Logger    *slog.Logger
-	Source    DNSSource
-	StartTime time.Time
-	IpAddr    string
-
-	// Metrics collection
 	telemetry *metrics.TelemetryData
-}
-
-type TelemetryEvent struct {
-	ctx     *RequestContext
-	latency float64
+	logger    *slog.Logger
 }
 
 type DispatcherFunc func(writer dns.ResponseWriter, req *dns.Msg)
@@ -49,13 +39,13 @@ type DNSDispatcher struct {
 	blockList   *blocklist.BlockList
 	metrics     *metrics.DnsMetrics
 	logger      *slog.Logger
-	telemetryCh chan TelemetryEvent
+	telemetryCh chan *metrics.TelemetryData
 	done        chan struct{}
 }
 
 func NewDNSDispatcher(
 	cache *DNSCache,
-	metrics *metrics.DnsMetrics,
+	dnsMetrics *metrics.DnsMetrics,
 	dnsClient *RoundRobinClient,
 	blockList *blocklist.BlockList,
 	ttlFloor time.Duration,
@@ -72,9 +62,9 @@ func NewDNSDispatcher(
 		ttlFloor:    ttlFloor,
 		cache:       cache,
 		blockList:   blockList,
-		metrics:     metrics,
+		metrics:     dnsMetrics,
 		logger:      logger,
-		telemetryCh: make(chan TelemetryEvent, TELEMETRY_BUFFER_SIZE),
+		telemetryCh: make(chan *metrics.TelemetryData, TELEMETRY_BUFFER_SIZE),
 		done:        make(chan struct{}),
 	}
 
@@ -105,17 +95,13 @@ func (d *DNSDispatcher) HandleDNSRequest(source DNSSource) DispatcherFunc {
 		}
 
 		ctx := &RequestContext{
-			Logger:    d.logger.With("client_ip", ipAddr, "request_id", req.Id, "source", source),
-			Source:    source,
-			StartTime: time.Now(),
-			IpAddr:    ipAddr,
-			telemetry: &metrics.TelemetryData{},
+			logger:    d.logger.With("client_ip", ipAddr, "request_id", req.Id, "source", source),
+			telemetry: metrics.NewTelemetryData(time.Now(), string(source), ipAddr),
 		}
 
 		defer func() {
-			duration := time.Since(ctx.StartTime).Seconds()
 			select {
-			case d.telemetryCh <- TelemetryEvent{ctx: ctx, latency: duration}:
+			case d.telemetryCh <- ctx.telemetry.Finished():
 			default:
 				d.metrics.DroppedTelemetry.Inc()
 			}
@@ -171,11 +157,11 @@ func (d *DNSDispatcher) HandleDNSRequest(source DNSSource) DispatcherFunc {
 func (d *DNSDispatcher) telemetryWorker() {
 	for {
 		select {
-		case event, ok := <-d.telemetryCh:
+		case telemetry, ok := <-d.telemetryCh:
 			if !ok {
 				return
 			}
-			d.metrics.RecordTelemetry(event.ctx.telemetry, event.latency, string(event.ctx.Source), event.ctx.IpAddr)
+			telemetry.Record(d.metrics)
 		case <-d.done:
 			return
 		}
@@ -184,7 +170,7 @@ func (d *DNSDispatcher) telemetryWorker() {
 
 func (d *DNSDispatcher) processQuestion(ctx *RequestContext, q *dns.Question) ([]dns.RR, int, error) {
 	queryType := getQueryType(q)
-	ctx.Logger.Debug("Query received",
+	ctx.logger.Debug("Query received",
 		"name", q.Name,
 		"type", queryType)
 
@@ -195,7 +181,7 @@ func (d *DNSDispatcher) processQuestion(ctx *RequestContext, q *dns.Question) ([
 	}
 
 	if isBlocked {
-		ctx.Logger.Debug("Domain blocked", "name", q.Name)
+		ctx.logger.Debug("Domain blocked", "name", q.Name)
 		ctx.telemetry.AddBlockedDomain(q.Name)
 		ctx.telemetry.AddQueryCount(queryType, true)
 
@@ -217,7 +203,7 @@ func (d *DNSDispatcher) processQuestion(ctx *RequestContext, q *dns.Question) ([
 	}
 
 	if isReservedLocalhost(q.Name) {
-		ctx.Logger.Debug("Answering localhost loopback", "name", q.Name)
+		ctx.logger.Debug("Answering localhost loopback", "name", q.Name)
 		a := &dns.A{
 			Hdr: dns.RR_Header{
 				Name:   q.Name,
@@ -231,12 +217,12 @@ func (d *DNSDispatcher) processQuestion(ctx *RequestContext, q *dns.Question) ([
 	}
 
 	if isReservedTLD(q.Name) {
-		ctx.Logger.Debug("Blocking reserved TLD", "name", q.Name)
+		ctx.logger.Debug("Blocking reserved TLD", "name", q.Name)
 		return nil, dns.RcodeNameError, nil
 	}
 
 	if isDNSSDQuery(q.Name) {
-		ctx.Logger.Debug("Short-circuiting DNS-SD query", "name", q.Name)
+		ctx.logger.Debug("Short-circuiting DNS-SD query", "name", q.Name)
 		ctx.telemetry.AddQueryCount(queryType, false)
 		return nil, dns.RcodeNameError, nil
 	}
@@ -289,7 +275,7 @@ func (d *DNSDispatcher) resolveUpstream(ctx *RequestContext, unansweredQuestions
 			}
 
 			d.cache.Set(key, answersForQuestion, effectiveTTL)
-			ctx.telemetry.SetUpstreamTTL(getQueryType(&q), float64(upstreamTTL))
+			ctx.telemetry.AddUpstreamTTL(getQueryType(&q), float64(upstreamTTL))
 		}
 	}
 
@@ -318,7 +304,7 @@ var freshnessSensitive = []string{"ocsp", "crl", "pki"}
 func (d *DNSDispatcher) reportError(ctx *RequestContext, errorCategory string, err error, additionalFields ...any) {
 	if ShouldLog(err) {
 		args := append(additionalFields, "category", errorCategory, "error", err)
-		ctx.Logger.Error("DNS error", args...)
+		ctx.logger.Error("DNS error", args...)
 		sentry.CaptureException(err)
 	}
 

--- a/internal/forwarder/dispatcher.go
+++ b/internal/forwarder/dispatcher.go
@@ -10,7 +10,6 @@ import (
 	"github.com/getsentry/sentry-go"
 	"github.com/miekg/dns"
 	"github.com/rm-hull/dot-block/internal/blocklist"
-	"github.com/rm-hull/dot-block/internal/geoblock"
 	"github.com/rm-hull/dot-block/internal/metrics"
 )
 
@@ -58,7 +57,6 @@ type DNSDispatcher struct {
 	ttlFloor    time.Duration
 	cache       *DNSCache
 	blockList   *blocklist.BlockList
-	geoIpLookup geoblock.GeoIpLookup
 	metrics     *metrics.DnsMetrics
 	logger      *slog.Logger
 	telemetryCh chan TelemetryEvent
@@ -70,7 +68,6 @@ func NewDNSDispatcher(
 	metrics *metrics.DnsMetrics,
 	dnsClient *RoundRobinClient,
 	blockList *blocklist.BlockList,
-	geoIpLookup geoblock.GeoIpLookup,
 	ttlFloor time.Duration,
 	logger *slog.Logger,
 ) (*DNSDispatcher, error) {
@@ -85,7 +82,6 @@ func NewDNSDispatcher(
 		ttlFloor:    ttlFloor,
 		cache:       cache,
 		blockList:   blockList,
-		geoIpLookup: geoIpLookup,
 		metrics:     metrics,
 		logger:      logger,
 		telemetryCh: make(chan TelemetryEvent, TELEMETRY_BUFFER_SIZE),
@@ -189,26 +185,11 @@ func (d *DNSDispatcher) telemetryWorker() {
 			if !ok {
 				return
 			}
-			
-			countryCode := ""
-			if event.ctx.IpAddr != "unknown" && event.ctx.IpAddr != "" {
-				loc, err := d.geoIpLookup.GetAll(event.ctx.IpAddr)
-				if err != nil {
-					event.ctx.Logger.Warn("failed to get geolocation for client IP", "error", err)
-				} else {
-					countryCode = loc.Country_short
-				}
-			}
-
-			d.metrics.RecordTelemetry(event.ctx.telemetry, event.latency, string(event.ctx.Source), event.ctx.IpAddr, countryCode)
+			d.metrics.RecordTelemetry(event.ctx.telemetry, event.latency, string(event.ctx.Source), event.ctx.IpAddr)
 		case <-d.done:
 			return
 		}
 	}
-}
-
-func (d *DNSDispatcher) recordTelemetry(ctx *RequestContext, latency float64) {
-	// This method is no longer used.
 }
 
 func (d *DNSDispatcher) processQuestion(ctx *RequestContext, q *dns.Question) ([]dns.RR, int, error) {

--- a/internal/forwarder/dispatcher.go
+++ b/internal/forwarder/dispatcher.go
@@ -206,8 +206,8 @@ func (d *DNSDispatcher) processQuestion(ctx *RequestContext, q *dns.Question) ([
 
 	if isBlocked {
 		ctx.Logger.Debug("Domain blocked", "name", q.Name)
-		ctx.telemetry.BlockedDomains = append(ctx.telemetry.BlockedDomains, q.Name)
-		ctx.telemetry.QueryCounts = append(ctx.telemetry.QueryCounts, metrics.QueryCountInfo{QueryType: queryType, Blocked: true})
+		ctx.telemetry.AddBlockedDomain(q.Name)
+		ctx.telemetry.AddQueryCount(queryType, true)
 
 		soa := &dns.SOA{
 			Hdr: dns.RR_Header{
@@ -247,12 +247,12 @@ func (d *DNSDispatcher) processQuestion(ctx *RequestContext, q *dns.Question) ([
 
 	if isDNSSDQuery(q.Name) {
 		ctx.Logger.Debug("Short-circuiting DNS-SD query", "name", q.Name)
-		ctx.telemetry.QueryCounts = append(ctx.telemetry.QueryCounts, metrics.QueryCountInfo{QueryType: queryType, Blocked: false})
+		ctx.telemetry.AddQueryCount(queryType, false)
 		return nil, dns.RcodeNameError, nil
 	}
 
-	ctx.telemetry.Domains = append(ctx.telemetry.Domains, q.Name)
-	ctx.telemetry.QueryCounts = append(ctx.telemetry.QueryCounts, metrics.QueryCountInfo{QueryType: queryType, Blocked: false})
+	ctx.telemetry.AddDomain(q.Name)
+	ctx.telemetry.AddQueryCount(queryType, false)
 	if cachedRRs, ok := d.cache.Get(getCacheKey(q)); ok {
 		return cachedRRs, dns.RcodeSuccess, nil
 	}
@@ -299,7 +299,7 @@ func (d *DNSDispatcher) resolveUpstream(ctx *RequestContext, unansweredQuestions
 			}
 
 			d.cache.Set(key, answersForQuestion, effectiveTTL)
-			ctx.telemetry.UpstreamTTL = &metrics.UpstreamTTLInfo{QueryType: getQueryType(&q), TTL: float64(upstreamTTL)}
+			ctx.telemetry.SetUpstreamTTL(getQueryType(&q), float64(upstreamTTL))
 		}
 	}
 
@@ -332,23 +332,22 @@ func (d *DNSDispatcher) reportError(ctx *RequestContext, errorCategory string, e
 		sentry.CaptureException(err)
 	}
 
-	ctx.telemetry.ErrorCategory = errorCategory
-	ctx.telemetry.RequestTypes = append(ctx.telemetry.RequestTypes, "errored")
+	ctx.telemetry.SetErrorCategory(errorCategory)
+	ctx.telemetry.AddRequestType("errored")
 }
 
 func (d *DNSDispatcher) forwardQuery(ctx *RequestContext, req *dns.Msg) (*dns.Msg, string, error) {
 	startTime := time.Now()
-	ctx.telemetry.RequestTypes = append(ctx.telemetry.RequestTypes, "forwarded")
+	ctx.telemetry.AddRequestType("forwarded")
 	in, upstream, err := d.dnsClient.Exchange(req)
 
 	duration := time.Since(startTime).Seconds()
-	ctx.telemetry.Upstream = upstream
-	ctx.telemetry.UpstreamLatency = duration
+	ctx.telemetry.SetUpstream(upstream, duration)
 	return in, upstream, err
 }
 
 func (d *DNSDispatcher) sendResponse(ctx *RequestContext, writer dns.ResponseWriter, msg *dns.Msg) {
-	ctx.telemetry.Rcode = dns.RcodeToString[msg.Rcode]
+	ctx.telemetry.SetRcode(dns.RcodeToString[msg.Rcode])
 	if err := writer.WriteMsg(msg); err != nil {
 		d.reportError(ctx, "response", err)
 		return

--- a/internal/forwarder/dispatcher.go
+++ b/internal/forwarder/dispatcher.go
@@ -309,12 +309,11 @@ func (d *DNSDispatcher) reportError(ctx *RequestContext, errorCategory string, e
 	}
 
 	ctx.telemetry.SetErrorCategory(errorCategory)
-	ctx.telemetry.AddRequestType("errored")
 }
 
 func (d *DNSDispatcher) forwardQuery(ctx *RequestContext, req *dns.Msg) (*dns.Msg, string, error) {
 	startTime := time.Now()
-	ctx.telemetry.AddRequestType("forwarded")
+	ctx.telemetry.Forwarded()
 	in, upstream, err := d.dnsClient.Exchange(req)
 
 	duration := time.Since(startTime).Seconds()

--- a/internal/forwarder/dispatcher_test.go
+++ b/internal/forwarder/dispatcher_test.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/ip2location/ip2location-go/v9"
 	"github.com/miekg/dns"
 	"github.com/rm-hull/dot-block/internal/blocklist"
 	"github.com/rm-hull/dot-block/internal/metrics"
@@ -23,9 +24,9 @@ type MockGeoIpLookup struct {
 	mock.Mock
 }
 
-func (m *MockGeoIpLookup) GetAll(ipAddress string) (string, error) {
+func (m *MockGeoIpLookup) GetAll(ipAddress string) (ip2location.IP2Locationrecord, error) {
 	args := m.Called(ipAddress)
-	return args.String(0), args.Error(1)
+	return args.Get(0).(ip2location.IP2Locationrecord), args.Error(1)
 }
 
 func (m *MockGeoIpLookup) Reopen() error {
@@ -85,7 +86,7 @@ func setupDispatcherTest(t *testing.T, upstream string, logger *slog.Logger) (*D
 
 	cache := NewDNSCache(100, logger)
 	mockGeo := new(MockGeoIpLookup)
-	mockGeo.On("GetAll", mock.Anything).Return("", nil)
+	mockGeo.On("GetAll", mock.Anything).Return(ip2location.IP2Locationrecord{}, nil)
 
 	metrics, err := metrics.NewDNSMetrics(cache, mockGeo)
 	require.NoError(t, err)
@@ -332,7 +333,7 @@ func TestDNSDispatcher_NegativeCacheTtlFloor(t *testing.T) {
 
 	cache := NewDNSCache(100, logger)
 	mockGeo := new(MockGeoIpLookup)
-	mockGeo.On("GetAll", mock.Anything).Return("", nil)
+	mockGeo.On("GetAll", mock.Anything).Return(ip2location.IP2Locationrecord{}, nil)
 
 	metrics, err := metrics.NewDNSMetrics(cache, mockGeo)
 	assert.NoError(t, err)

--- a/internal/forwarder/dispatcher_test.go
+++ b/internal/forwarder/dispatcher_test.go
@@ -10,7 +10,6 @@ import (
 	"time"
 
 	"github.com/google/uuid"
-	"github.com/ip2location/ip2location-go/v9"
 	"github.com/miekg/dns"
 	"github.com/rm-hull/dot-block/internal/blocklist"
 	"github.com/rm-hull/dot-block/internal/metrics"
@@ -24,9 +23,9 @@ type MockGeoIpLookup struct {
 	mock.Mock
 }
 
-func (m *MockGeoIpLookup) GetAll(ipAddress string) (ip2location.IP2Locationrecord, error) {
+func (m *MockGeoIpLookup) GetAll(ipAddress string) (string, error) {
 	args := m.Called(ipAddress)
-	return args.Get(0).(ip2location.IP2Locationrecord), args.Error(1)
+	return args.String(0), args.Error(1)
 }
 
 func (m *MockGeoIpLookup) Reopen() error {
@@ -85,16 +84,16 @@ func setupDispatcherTest(t *testing.T, upstream string, logger *slog.Logger) (*D
 	blockList := blocklist.NewBlockList([]string{"ads.0xbt.net"}, 0.0001, logger)
 
 	cache := NewDNSCache(100, logger)
-	metrics, err := metrics.NewDNSMetrics(cache)
+	mockGeo := new(MockGeoIpLookup)
+	mockGeo.On("GetAll", mock.Anything).Return("", nil)
+
+	metrics, err := metrics.NewDNSMetrics(cache, mockGeo)
 	require.NoError(t, err)
 
 	dnsClient, err := NewRoundRobinClient(metrics, 2*time.Second, 1, logger, upstream)
 	require.NoError(t, err)
 
-	mockGeo := new(MockGeoIpLookup)
-	mockGeo.On("GetAll", mock.Anything).Return(ip2location.IP2Locationrecord{}, nil)
-
-	dispatcher, err := NewDNSDispatcher(cache, metrics, dnsClient, blockList, mockGeo, 1*time.Minute, logger)
+	dispatcher, err := NewDNSDispatcher(cache, metrics, dnsClient, blockList, 1*time.Minute, logger)
 	require.NoError(t, err)
 	t.Cleanup(dispatcher.Close)
 
@@ -332,14 +331,16 @@ func TestDNSDispatcher_NegativeCacheTtlFloor(t *testing.T) {
 	blockList := blocklist.NewBlockList([]string{"ads.0xbt.net"}, 0.0001, logger)
 
 	cache := NewDNSCache(100, logger)
-	metrics, err := metrics.NewDNSMetrics(cache)
+	mockGeo := new(MockGeoIpLookup)
+	mockGeo.On("GetAll", mock.Anything).Return("", nil)
+
+	metrics, err := metrics.NewDNSMetrics(cache, mockGeo)
 	assert.NoError(t, err)
 
 	dnsClient, err := NewRoundRobinClient(metrics, 2*time.Second, 1, logger, "8.8.8.8:53")
 	assert.NoError(t, err)
-	mockGeo := new(MockGeoIpLookup)
 
-	dispatcher, err := NewDNSDispatcher(cache, metrics, dnsClient, blockList, mockGeo, -1*time.Second, logger)
+	dispatcher, err := NewDNSDispatcher(cache, metrics, dnsClient, blockList, -1*time.Second, logger)
 	assert.Error(t, err)
 	assert.Nil(t, dispatcher)
 	assert.Contains(t, err.Error(), "TTL floor cannot be negative")

--- a/internal/metrics/dns_metrics.go
+++ b/internal/metrics/dns_metrics.go
@@ -25,15 +25,48 @@ type UpstreamTTLInfo struct {
 }
 
 type TelemetryData struct {
-	BlockedDomains  []string
-	Domains         []string
-	QueryCounts     []QueryCountInfo
-	UpstreamTTL     *UpstreamTTLInfo
-	ErrorCategory   string
-	RequestTypes    []string
-	Upstream        string
-	UpstreamLatency float64
-	Rcode           string
+	blockedDomains  []string
+	domains         []string
+	queryCounts     []QueryCountInfo
+	upstreamTTL     *UpstreamTTLInfo
+	errorCategory   string
+	requestTypes    []string
+	upstream        string
+	upstreamLatency float64
+	rcode           string
+}
+
+func (t *TelemetryData) AddBlockedDomain(domain string) {
+	t.blockedDomains = append(t.blockedDomains, domain)
+}
+
+func (t *TelemetryData) AddDomain(domain string) {
+	t.domains = append(t.domains, domain)
+}
+
+func (t *TelemetryData) AddQueryCount(queryType string, blocked bool) {
+	t.queryCounts = append(t.queryCounts, QueryCountInfo{QueryType: queryType, Blocked: blocked})
+}
+
+func (t *TelemetryData) SetUpstreamTTL(queryType string, ttl float64) {
+	t.upstreamTTL = &UpstreamTTLInfo{QueryType: queryType, TTL: ttl}
+}
+
+func (t *TelemetryData) SetErrorCategory(category string) {
+	t.errorCategory = category
+}
+
+func (t *TelemetryData) AddRequestType(requestType string) {
+	t.requestTypes = append(t.requestTypes, requestType)
+}
+
+func (t *TelemetryData) SetUpstream(upstream string, latency float64) {
+	t.upstream = upstream
+	t.upstreamLatency = latency
+}
+
+func (t *TelemetryData) SetRcode(rcode string) {
+	t.rcode = rcode
 }
 
 // GeoIpLookup is an interface for looking up geolocation information.
@@ -73,29 +106,29 @@ func (m *DnsMetrics) RecordTelemetry(data *TelemetryData, latency float64, sourc
 		}
 	}
 
-	for _, qc := range data.QueryCounts {
+	for _, qc := range data.queryCounts {
 		m.QueryCounts.WithLabelValues(qc.QueryType, fmt.Sprintf("%t", qc.Blocked)).Inc()
 	}
-	for _, domain := range data.BlockedDomains {
+	for _, domain := range data.blockedDomains {
 		m.TopBlockedDomains.Add(domain)
 	}
-	for _, domain := range data.Domains {
+	for _, domain := range data.domains {
 		m.TopDomains.Add(domain)
 	}
-	if data.UpstreamTTL != nil {
-		m.UpstreamTTLs.WithLabelValues(data.UpstreamTTL.QueryType).Observe(data.UpstreamTTL.TTL)
+	if data.upstreamTTL != nil {
+		m.UpstreamTTLs.WithLabelValues(data.upstreamTTL.QueryType).Observe(data.upstreamTTL.TTL)
 	}
-	if data.ErrorCategory != "" {
-		m.ErrorCounts.WithLabelValues(data.ErrorCategory).Inc()
+	if data.errorCategory != "" {
+		m.ErrorCounts.WithLabelValues(data.errorCategory).Inc()
 	}
-	for _, rt := range data.RequestTypes {
+	for _, rt := range data.requestTypes {
 		m.RequestCounts.WithLabelValues(rt, source).Inc()
 	}
-	if data.Upstream != "" {
-		m.UpstreamLatency.WithLabelValues(data.Upstream).Observe(data.UpstreamLatency)
+	if data.upstream != "" {
+		m.UpstreamLatency.WithLabelValues(data.upstream).Observe(data.upstreamLatency)
 	}
-	if data.Rcode != "" {
-		m.ReplyCounts.WithLabelValues(data.Rcode).Inc()
+	if data.rcode != "" {
+		m.ReplyCounts.WithLabelValues(data.rcode).Inc()
 	}
 }
 

--- a/internal/metrics/dns_metrics.go
+++ b/internal/metrics/dns_metrics.go
@@ -14,6 +14,28 @@ import (
 
 const TOP_K = 50
 
+type QueryCountInfo struct {
+	QueryType string
+	Blocked   bool
+}
+
+type UpstreamTTLInfo struct {
+	QueryType string
+	TTL       float64
+}
+
+type TelemetryData struct {
+	BlockedDomains  []string
+	Domains         []string
+	QueryCounts     []QueryCountInfo
+	UpstreamTTL     *UpstreamTTLInfo
+	ErrorCategory   string
+	RequestTypes    []string
+	Upstream        string
+	UpstreamLatency float64
+	Rcode           string
+}
+
 type SafeSketch struct {
 	mu     sync.Mutex
 	sketch *hyperloglog.Sketch
@@ -29,6 +51,44 @@ func (s *SafeSketch) Estimate() uint64 {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	return s.sketch.Estimate()
+}
+
+func (m *DnsMetrics) RecordTelemetry(data *TelemetryData, latency float64, source string, ipAddr string, countryCode string) {
+	m.RequestLatency.Observe(latency)
+	m.RequestCounts.WithLabelValues("total", source).Inc()
+
+	if ipAddr != "" && ipAddr != "unknown" {
+		m.TopClients.Add(ipAddr)
+		m.UniqueClients.Insert([]byte(ipAddr))
+		if countryCode != "" {
+			m.CountryCounts.WithLabelValues(countryCode).Inc()
+		}
+	}
+
+	for _, qc := range data.QueryCounts {
+		m.QueryCounts.WithLabelValues(qc.QueryType, fmt.Sprintf("%t", qc.Blocked)).Inc()
+	}
+	for _, domain := range data.BlockedDomains {
+		m.TopBlockedDomains.Add(domain)
+	}
+	for _, domain := range data.Domains {
+		m.TopDomains.Add(domain)
+	}
+	if data.UpstreamTTL != nil {
+		m.UpstreamTTLs.WithLabelValues(data.UpstreamTTL.QueryType).Observe(data.UpstreamTTL.TTL)
+	}
+	if data.ErrorCategory != "" {
+		m.ErrorCounts.WithLabelValues(data.ErrorCategory).Inc()
+	}
+	for _, rt := range data.RequestTypes {
+		m.RequestCounts.WithLabelValues(rt, source).Inc()
+	}
+	if data.Upstream != "" {
+		m.UpstreamLatency.WithLabelValues(data.Upstream).Observe(data.UpstreamLatency)
+	}
+	if data.Rcode != "" {
+		m.ReplyCounts.WithLabelValues(data.Rcode).Inc()
+	}
 }
 
 type DnsMetrics struct {

--- a/internal/metrics/dns_metrics.go
+++ b/internal/metrics/dns_metrics.go
@@ -8,71 +8,12 @@ import (
 	"github.com/axiomhq/hyperloglog"
 	"github.com/cockroachdb/errors"
 	cache "github.com/go-pkgz/expirable-cache/v3"
+	"github.com/rm-hull/dot-block/internal/geoblock"
 
 	"github.com/prometheus/client_golang/prometheus"
 )
 
 const TOP_K = 50
-
-type QueryCountInfo struct {
-	QueryType string
-	Blocked   bool
-}
-
-type UpstreamTTLInfo struct {
-	QueryType string
-	TTL       float64
-}
-
-type TelemetryData struct {
-	blockedDomains  []string
-	domains         []string
-	queryCounts     []QueryCountInfo
-	upstreamTTL     *UpstreamTTLInfo
-	errorCategory   string
-	requestTypes    []string
-	upstream        string
-	upstreamLatency float64
-	rcode           string
-}
-
-func (t *TelemetryData) AddBlockedDomain(domain string) {
-	t.blockedDomains = append(t.blockedDomains, domain)
-}
-
-func (t *TelemetryData) AddDomain(domain string) {
-	t.domains = append(t.domains, domain)
-}
-
-func (t *TelemetryData) AddQueryCount(queryType string, blocked bool) {
-	t.queryCounts = append(t.queryCounts, QueryCountInfo{QueryType: queryType, Blocked: blocked})
-}
-
-func (t *TelemetryData) SetUpstreamTTL(queryType string, ttl float64) {
-	t.upstreamTTL = &UpstreamTTLInfo{QueryType: queryType, TTL: ttl}
-}
-
-func (t *TelemetryData) SetErrorCategory(category string) {
-	t.errorCategory = category
-}
-
-func (t *TelemetryData) AddRequestType(requestType string) {
-	t.requestTypes = append(t.requestTypes, requestType)
-}
-
-func (t *TelemetryData) SetUpstream(upstream string, latency float64) {
-	t.upstream = upstream
-	t.upstreamLatency = latency
-}
-
-func (t *TelemetryData) SetRcode(rcode string) {
-	t.rcode = rcode
-}
-
-// GeoIpLookup is an interface for looking up geolocation information.
-type GeoIpLookup interface {
-	GetAll(ipAddress string) (string, error)
-}
 
 type SafeSketch struct {
 	mu     sync.Mutex
@@ -89,47 +30,6 @@ func (s *SafeSketch) Estimate() uint64 {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	return s.sketch.Estimate()
-}
-
-func (m *DnsMetrics) RecordTelemetry(data *TelemetryData, latency float64, source string, ipAddr string) {
-	m.RequestLatency.Observe(latency)
-	m.RequestCounts.WithLabelValues("total", source).Inc()
-
-	if ipAddr != "" && ipAddr != "unknown" {
-		m.TopClients.Add(ipAddr)
-		m.UniqueClients.Insert([]byte(ipAddr))
-
-		if m.geoIpLookup != nil {
-			if countryCode, err := m.geoIpLookup.GetAll(ipAddr); err == nil && countryCode != "" {
-				m.CountryCounts.WithLabelValues(countryCode).Inc()
-			}
-		}
-	}
-
-	for _, qc := range data.queryCounts {
-		m.QueryCounts.WithLabelValues(qc.QueryType, fmt.Sprintf("%t", qc.Blocked)).Inc()
-	}
-	for _, domain := range data.blockedDomains {
-		m.TopBlockedDomains.Add(domain)
-	}
-	for _, domain := range data.domains {
-		m.TopDomains.Add(domain)
-	}
-	if data.upstreamTTL != nil {
-		m.UpstreamTTLs.WithLabelValues(data.upstreamTTL.QueryType).Observe(data.upstreamTTL.TTL)
-	}
-	if data.errorCategory != "" {
-		m.ErrorCounts.WithLabelValues(data.errorCategory).Inc()
-	}
-	for _, rt := range data.requestTypes {
-		m.RequestCounts.WithLabelValues(rt, source).Inc()
-	}
-	if data.upstream != "" {
-		m.UpstreamLatency.WithLabelValues(data.upstream).Observe(data.upstreamLatency)
-	}
-	if data.rcode != "" {
-		m.ReplyCounts.WithLabelValues(data.rcode).Inc()
-	}
 }
 
 type DnsMetrics struct {
@@ -151,7 +51,7 @@ type DnsMetrics struct {
 	PoolEvictions       *prometheus.CounterVec
 	UpstreamFailures    *prometheus.CounterVec
 	PooledConnDeaths    *prometheus.CounterVec
-	geoIpLookup         GeoIpLookup
+	geoIpLookup         geoblock.GeoIpLookup
 }
 
 var latencyBuckets = []float64{
@@ -165,7 +65,7 @@ type Cache interface {
 	OnDrop(func())
 }
 
-func NewDNSMetrics(cache Cache, geoIpLookup GeoIpLookup) (*DnsMetrics, error) {
+func NewDNSMetrics(cache Cache, geoIpLookup geoblock.GeoIpLookup) (*DnsMetrics, error) {
 	uniqueClients := &SafeSketch{sketch: hyperloglog.New14()}
 	topClients := NewSpaceSaver(TOP_K)
 	topDomains := NewSpaceSaver(TOP_K)

--- a/internal/metrics/dns_metrics.go
+++ b/internal/metrics/dns_metrics.go
@@ -36,6 +36,11 @@ type TelemetryData struct {
 	Rcode           string
 }
 
+// GeoIpLookup is an interface for looking up geolocation information.
+type GeoIpLookup interface {
+	GetAll(ipAddress string) (string, error)
+}
+
 type SafeSketch struct {
 	mu     sync.Mutex
 	sketch *hyperloglog.Sketch
@@ -53,15 +58,18 @@ func (s *SafeSketch) Estimate() uint64 {
 	return s.sketch.Estimate()
 }
 
-func (m *DnsMetrics) RecordTelemetry(data *TelemetryData, latency float64, source string, ipAddr string, countryCode string) {
+func (m *DnsMetrics) RecordTelemetry(data *TelemetryData, latency float64, source string, ipAddr string) {
 	m.RequestLatency.Observe(latency)
 	m.RequestCounts.WithLabelValues("total", source).Inc()
 
 	if ipAddr != "" && ipAddr != "unknown" {
 		m.TopClients.Add(ipAddr)
 		m.UniqueClients.Insert([]byte(ipAddr))
-		if countryCode != "" {
-			m.CountryCounts.WithLabelValues(countryCode).Inc()
+
+		if m.geoIpLookup != nil {
+			if countryCode, err := m.geoIpLookup.GetAll(ipAddr); err == nil && countryCode != "" {
+				m.CountryCounts.WithLabelValues(countryCode).Inc()
+			}
 		}
 	}
 
@@ -110,6 +118,7 @@ type DnsMetrics struct {
 	PoolEvictions       *prometheus.CounterVec
 	UpstreamFailures    *prometheus.CounterVec
 	PooledConnDeaths    *prometheus.CounterVec
+	geoIpLookup         GeoIpLookup
 }
 
 var latencyBuckets = []float64{
@@ -123,7 +132,7 @@ type Cache interface {
 	OnDrop(func())
 }
 
-func NewDNSMetrics(cache Cache) (*DnsMetrics, error) {
+func NewDNSMetrics(cache Cache, geoIpLookup GeoIpLookup) (*DnsMetrics, error) {
 	uniqueClients := &SafeSketch{sketch: hyperloglog.New14()}
 	topClients := NewSpaceSaver(TOP_K)
 	topDomains := NewSpaceSaver(TOP_K)
@@ -287,6 +296,7 @@ func NewDNSMetrics(cache Cache) (*DnsMetrics, error) {
 		PoolEvictions:       poolEvictions,
 		UpstreamFailures:    upstreamFailures,
 		PooledConnDeaths:    pooledConnDeaths,
+		geoIpLookup:         geoIpLookup,
 	}, nil
 }
 

--- a/internal/metrics/telemetry.go
+++ b/internal/metrics/telemetry.go
@@ -2,14 +2,14 @@ package metrics
 
 import "time"
 
-type QueryCountInfo struct {
-	QueryType string
-	Blocked   bool
+type queryCountInfo struct {
+	queryType string
+	blocked   bool
 }
 
-type UpstreamTTLInfo struct {
-	QueryType string
-	TTL       float64
+type upstreamTTLInfo struct {
+	queryType string
+	ttl       float64
 }
 
 type TelemetryData struct {
@@ -18,10 +18,10 @@ type TelemetryData struct {
 	startTime       time.Time
 	blockedDomains  []string
 	domains         []string
-	queryCounts     []QueryCountInfo
-	upstreamTTLs    []UpstreamTTLInfo
+	queryCounts     []queryCountInfo
+	upstreamTTLs    []upstreamTTLInfo
 	errorCategory   string
-	requestTypes    []string
+	forwarded       bool
 	upstream        string
 	upstreamLatency float64
 	requestLatency  float64
@@ -40,9 +40,8 @@ func NewTelemetryData(startTime time.Time, source string, ipAddr string) *Teleme
 		ipAddr:         ipAddr,
 		blockedDomains: []string{},
 		domains:        []string{},
-		queryCounts:    []QueryCountInfo{},
-		upstreamTTLs:   []UpstreamTTLInfo{},
-		requestTypes:   []string{},
+		queryCounts:    []queryCountInfo{},
+		upstreamTTLs:   []upstreamTTLInfo{},
 	}
 }
 
@@ -55,19 +54,19 @@ func (t *TelemetryData) AddDomain(domain string) {
 }
 
 func (t *TelemetryData) AddQueryCount(queryType string, blocked bool) {
-	t.queryCounts = append(t.queryCounts, QueryCountInfo{QueryType: queryType, Blocked: blocked})
+	t.queryCounts = append(t.queryCounts, queryCountInfo{queryType: queryType, blocked: blocked})
 }
 
 func (t *TelemetryData) AddUpstreamTTL(queryType string, ttl float64) {
-	t.upstreamTTLs = append(t.upstreamTTLs, UpstreamTTLInfo{QueryType: queryType, TTL: ttl})
+	t.upstreamTTLs = append(t.upstreamTTLs, upstreamTTLInfo{queryType: queryType, ttl: ttl})
 }
 
 func (t *TelemetryData) SetErrorCategory(category string) {
 	t.errorCategory = category
 }
 
-func (t *TelemetryData) AddRequestType(requestType string) {
-	t.requestTypes = append(t.requestTypes, requestType)
+func (t *TelemetryData) Forwarded() {
+	t.forwarded = true
 }
 
 func (t *TelemetryData) SetUpstream(upstream string, latency float64) {
@@ -82,6 +81,12 @@ func (t *TelemetryData) SetRcode(rcode string) {
 func (t *TelemetryData) Record(metrics *DnsMetrics) {
 	metrics.RequestLatency.Observe(t.requestLatency)
 	metrics.RequestCounts.WithLabelValues("total", t.source).Inc()
+	if t.forwarded {
+		metrics.RequestCounts.WithLabelValues("forwarded", t.source).Inc()
+	}
+	if t.errorCategory != "" {
+		metrics.RequestCounts.WithLabelValues("errored", t.source).Inc()
+	}
 
 	if t.ipAddr != "" && t.ipAddr != "unknown" {
 		metrics.TopClients.Add(t.ipAddr)
@@ -94,10 +99,10 @@ func (t *TelemetryData) Record(metrics *DnsMetrics) {
 
 	for _, qc := range t.queryCounts {
 		isBlocked := "false"
-		if qc.Blocked {
+		if qc.blocked {
 			isBlocked = "true"
 		}
-		metrics.QueryCounts.WithLabelValues(qc.QueryType, isBlocked).Inc()
+		metrics.QueryCounts.WithLabelValues(qc.queryType, isBlocked).Inc()
 	}
 	for _, domain := range t.blockedDomains {
 		metrics.TopBlockedDomains.Add(domain)
@@ -106,13 +111,10 @@ func (t *TelemetryData) Record(metrics *DnsMetrics) {
 		metrics.TopDomains.Add(domain)
 	}
 	for _, upstreamTTL := range t.upstreamTTLs {
-		metrics.UpstreamTTLs.WithLabelValues(upstreamTTL.QueryType).Observe(upstreamTTL.TTL)
+		metrics.UpstreamTTLs.WithLabelValues(upstreamTTL.queryType).Observe(upstreamTTL.ttl)
 	}
 	if t.errorCategory != "" {
 		metrics.ErrorCounts.WithLabelValues(t.errorCategory).Inc()
-	}
-	for _, rt := range t.requestTypes {
-		metrics.RequestCounts.WithLabelValues(rt, t.source).Inc()
 	}
 	if t.upstream != "" {
 		metrics.UpstreamLatency.WithLabelValues(t.upstream).Observe(t.upstreamLatency)

--- a/internal/metrics/telemetry.go
+++ b/internal/metrics/telemetry.go
@@ -1,0 +1,123 @@
+package metrics
+
+import "time"
+
+type QueryCountInfo struct {
+	QueryType string
+	Blocked   bool
+}
+
+type UpstreamTTLInfo struct {
+	QueryType string
+	TTL       float64
+}
+
+type TelemetryData struct {
+	source          string
+	ipAddr          string
+	startTime       time.Time
+	blockedDomains  []string
+	domains         []string
+	queryCounts     []QueryCountInfo
+	upstreamTTLs    []UpstreamTTLInfo
+	errorCategory   string
+	requestTypes    []string
+	upstream        string
+	upstreamLatency float64
+	requestLatency  float64
+	rcode           string
+}
+
+func (t *TelemetryData) Finished() *TelemetryData {
+	t.requestLatency = time.Since(t.startTime).Seconds()
+	return t
+}
+
+func NewTelemetryData(startTime time.Time, source string, ipAddr string) *TelemetryData {
+	return &TelemetryData{
+		startTime:      startTime,
+		source:         source,
+		ipAddr:         ipAddr,
+		blockedDomains: []string{},
+		domains:        []string{},
+		queryCounts:    []QueryCountInfo{},
+		upstreamTTLs:   []UpstreamTTLInfo{},
+		requestTypes:   []string{},
+	}
+}
+
+func (t *TelemetryData) AddBlockedDomain(domain string) {
+	t.blockedDomains = append(t.blockedDomains, domain)
+}
+
+func (t *TelemetryData) AddDomain(domain string) {
+	t.domains = append(t.domains, domain)
+}
+
+func (t *TelemetryData) AddQueryCount(queryType string, blocked bool) {
+	t.queryCounts = append(t.queryCounts, QueryCountInfo{QueryType: queryType, Blocked: blocked})
+}
+
+func (t *TelemetryData) AddUpstreamTTL(queryType string, ttl float64) {
+	t.upstreamTTLs = append(t.upstreamTTLs, UpstreamTTLInfo{QueryType: queryType, TTL: ttl})
+}
+
+func (t *TelemetryData) SetErrorCategory(category string) {
+	t.errorCategory = category
+}
+
+func (t *TelemetryData) AddRequestType(requestType string) {
+	t.requestTypes = append(t.requestTypes, requestType)
+}
+
+func (t *TelemetryData) SetUpstream(upstream string, latency float64) {
+	t.upstream = upstream
+	t.upstreamLatency = latency
+}
+
+func (t *TelemetryData) SetRcode(rcode string) {
+	t.rcode = rcode
+}
+
+func (t *TelemetryData) Record(metrics *DnsMetrics) {
+	metrics.RequestLatency.Observe(t.requestLatency)
+	metrics.RequestCounts.WithLabelValues("total", t.source).Inc()
+
+	if t.ipAddr != "" && t.ipAddr != "unknown" {
+		metrics.TopClients.Add(t.ipAddr)
+		metrics.UniqueClients.Insert([]byte(t.ipAddr))
+
+		if record, err := metrics.geoIpLookup.GetAll(t.ipAddr); err == nil && record.Country_short != "" {
+			metrics.CountryCounts.WithLabelValues(record.Country_short).Inc()
+		}
+	}
+
+	for _, qc := range t.queryCounts {
+		isBlocked := "false"
+		if qc.Blocked {
+			isBlocked = "true"
+		}
+		metrics.QueryCounts.WithLabelValues(qc.QueryType, isBlocked).Inc()
+	}
+	for _, domain := range t.blockedDomains {
+		metrics.TopBlockedDomains.Add(domain)
+	}
+	for _, domain := range t.domains {
+		metrics.TopDomains.Add(domain)
+	}
+	for _, upstreamTTL := range t.upstreamTTLs {
+		metrics.UpstreamTTLs.WithLabelValues(upstreamTTL.QueryType).Observe(upstreamTTL.TTL)
+	}
+	if t.errorCategory != "" {
+		metrics.ErrorCounts.WithLabelValues(t.errorCategory).Inc()
+	}
+	for _, rt := range t.requestTypes {
+		metrics.RequestCounts.WithLabelValues(rt, t.source).Inc()
+	}
+	if t.upstream != "" {
+		metrics.UpstreamLatency.WithLabelValues(t.upstream).Observe(t.upstreamLatency)
+	}
+	if t.rcode != "" {
+		metrics.ReplyCounts.WithLabelValues(t.rcode).Inc()
+	}
+}


### PR DESCRIPTION
Refactored telemetry recording to collect data within `RequestContext` instead of immediate metric emission. This ensures consistency and avoids partial updates during request processing.