### PR TITLE
feat: add latency to DNS error logs

### DIFF
--- a/internal/forwarder/dispatcher.go
+++ b/internal/forwarder/dispatcher.go
@@ -303,7 +303,7 @@ var freshnessSensitive = []string{"ocsp", "crl", "pki"}
 
 func (d *DNSDispatcher) reportError(ctx *RequestContext, errorCategory string, err error, additionalFields ...any) {
 	if ShouldLog(err) {
-		args := append(additionalFields, "category", errorCategory, "error", err)
+		args := append(additionalFields, "category", errorCategory, "error", err, "latency", ctx.telemetry.Latency())
 		ctx.logger.Error("DNS error", args...)
 		sentry.CaptureException(err)
 	}

--- a/internal/metrics/telemetry.go
+++ b/internal/metrics/telemetry.go
@@ -29,8 +29,12 @@ type TelemetryData struct {
 }
 
 func (t *TelemetryData) Finished() *TelemetryData {
-	t.requestLatency = time.Since(t.startTime).Seconds()
+	t.requestLatency = t.Latency()
 	return t
+}
+
+func (t *TelemetryData) Latency() float64 {
+	return time.Since(t.startTime).Seconds()
 }
 
 func NewTelemetryData(startTime time.Time, source string, ipAddr string) *TelemetryData {


### PR DESCRIPTION
Expose a `Latency()` helper method on `TelemetryData` and include the request latency in error logs to improve observability when debugging slow or failing DNS resolutions.