### PR TITLE
feat: add integrarion test (+support graceful shutdown and optional IP2Location)

### DIFF
--- a/internal/app.go
+++ b/internal/app.go
@@ -250,7 +250,7 @@ func (app *App) RunServer(ctx context.Context) error {
 		return errors.Wrap(err, "failed to create cache reaper cron job")
 	}
 
-	var group errgroup.Group
+	group, groupCtx := errgroup.WithContext(ctx)
 
 	group.Go(func() error {
 		app.Logger.Info("Starting HTTP server for mobileconfig, metrics & healthcheck", "port", app.HttpPort)
@@ -259,8 +259,10 @@ func (app *App) RunServer(ctx context.Context) error {
 			Handler: r,
 		}
 
-		app.monitorShutdown(ctx, "HTTP server", func() error {
-			return srv.Shutdown(context.Background())
+		app.monitorShutdown(groupCtx, "HTTP server", func() error {
+			shutdownCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+			defer cancel()
+			return srv.Shutdown(shutdownCtx)
 		})
 
 		if err := srv.ListenAndServe(); err != nil && err != http.ErrServerClosed {
@@ -281,7 +283,7 @@ func (app *App) RunServer(ctx context.Context) error {
 			Handler: dns.HandlerFunc(dispatcher.HandleDNSRequest(forwarder.SourceUDP)),
 		}
 
-		app.monitorShutdown(ctx, "UDP DNS server", srv.Shutdown)
+		app.monitorShutdown(groupCtx, "UDP DNS server", srv.Shutdown)
 		return srv.ListenAndServe()
 	})
 
@@ -297,7 +299,7 @@ func (app *App) RunServer(ctx context.Context) error {
 			Handler: dns.HandlerFunc(dispatcher.HandleDNSRequest(forwarder.SourceTCP)),
 		}
 
-		app.monitorShutdown(ctx, "TCP DNS server", srv.Shutdown)
+		app.monitorShutdown(groupCtx, "TCP DNS server", srv.Shutdown)
 		return srv.ListenAndServe()
 	})
 
@@ -338,7 +340,7 @@ func (app *App) RunServer(ctx context.Context) error {
 			Handler:  dns.HandlerFunc(dispatcher.HandleDNSRequest(forwarder.SourceDoT)),
 		}
 
-		app.monitorShutdown(ctx, "DoT server", srv.Shutdown)
+		app.monitorShutdown(groupCtx, "DoT server", srv.Shutdown)
 		return srv.ActivateAndServe()
 	})
 

--- a/internal/app.go
+++ b/internal/app.go
@@ -41,19 +41,20 @@ import (
 )
 
 type App struct {
-	Logger        *slog.Logger `json:"-"`
-	LogLevel      string       `json:"log_level"`
-	DevMode       bool         `json:"dev_mode"`
-	DataDir       string       `json:"data_dir"`
-	HttpPort      int          `json:"http_port"`
-	DnsPort       int          `json:"dns_port"`
-	DotPort       int          `json:"dot_port"`
-	Upstreams     []string     `json:"upstreams"`
-	BlockListURLs []string     `json:"blocklist_urls"`
-	AllowedHosts  []string     `json:"allowed_hosts"`
-	MetricsAuth   string       `json:"-"`
-	MaxCacheSize  int          `json:"max_cache_size"`
-	CronSchedule  struct {
+	Logger             *slog.Logger `json:"-"`
+	LogLevel           string       `json:"log_level"`
+	DevMode            bool         `json:"dev_mode"`
+	DataDir            string       `json:"data_dir"`
+	HttpPort           int          `json:"http_port"`
+	DnsPort            int          `json:"dns_port"`
+	DotPort            int          `json:"dot_port"`
+	Upstreams          []string     `json:"upstreams"`
+	BlockListURLs      []string     `json:"blocklist_urls"`
+	AllowedHosts       []string     `json:"allowed_hosts"`
+	MetricsAuth        string       `json:"-"`
+	MaxCacheSize       int          `json:"max_cache_size"`
+	DisableIp2Location bool         `json:"disable_ip2location"`
+	CronSchedule       struct {
 		Downloader  string `json:"downloader"`
 		CacheReaper string `json:"cache_reaper"`
 		IP2Location string `json:"ip2location"`
@@ -113,7 +114,18 @@ func structToMap(obj any) any {
 	return m
 }
 
-func (app *App) RunServer() error {
+func (app *App) monitorShutdown(ctx context.Context, name string, shutdownFn func() error) {
+	go func() {
+		<-ctx.Done()
+		if err := shutdownFn(); err != nil {
+			app.Logger.Error(name+" failed to shut down", "error", err)
+		} else {
+			app.Logger.Info(name + " shut down successfully")
+		}
+	}()
+}
+
+func (app *App) RunServer(ctx context.Context) error {
 	if err := godotenv.Load(); err != nil {
 		app.Logger.Warn("No .env file found")
 	}
@@ -149,24 +161,14 @@ func (app *App) RunServer() error {
 	crontab.Start()
 	defer crontab.Stop()
 
-	geolocationDb := fmt.Sprintf("%s/ip2location/IP2LOCATION-LITE-DB1.BIN", app.DataDir)
-	if _, err := os.Stat(geolocationDb); os.IsNotExist(err) {
-		app.Logger.Info("Geolocation database not found, downloading...")
-		_, err = geoblock.Fetch("DB1LITEBIN", app.DataDir, app.Logger)
+	var geoIpLookup geoblock.GeoIpLookup
+	if app.DisableIp2Location {
+		app.Logger.Warn("IP2Location lookups are disabled")
+	} else {
+		geoIpLookup, err = app.initIp2Location(crontab)
 		if err != nil {
-			return errors.Wrap(err, "failed to download geoblock database")
+			return errors.Wrap(err, "failed to initialize IP2Location")
 		}
-	}
-
-	app.Logger.Info("Loading geolocation database", "file", geolocationDb)
-	geoIpLookup, err := geoblock.NewGeoIpLookup(geolocationDb)
-	if err != nil {
-		return errors.Wrap(err, "failed to open geoblock database")
-	}
-
-	app.Logger.Info("Creating IP2Location updater cron job", "schedule", app.CronSchedule.IP2Location)
-	if _, err = crontab.AddJob(app.CronSchedule.IP2Location, geoblock.NewIp2LocationUpdaterCronJob(app.Logger, "DB1LITEBIN", app.DataDir, geoIpLookup)); err != nil {
-		return errors.Wrap(err, "failed to create IP2Location updater cron job")
 	}
 
 	allHosts := make([]string, 0)
@@ -252,7 +254,19 @@ func (app *App) RunServer() error {
 
 	group.Go(func() error {
 		app.Logger.Info("Starting HTTP server for mobileconfig, metrics & healthcheck", "port", app.HttpPort)
-		return r.Run(fmt.Sprintf(":%d", app.HttpPort))
+		srv := &http.Server{
+			Addr:    fmt.Sprintf(":%d", app.HttpPort),
+			Handler: r,
+		}
+
+		app.monitorShutdown(ctx, "HTTP server", func() error {
+			return srv.Shutdown(context.Background())
+		})
+
+		if err := srv.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+			return errors.Wrap(err, "HTTP server failed")
+		}
+		return nil
 	})
 
 	group.Go(func() error {
@@ -261,11 +275,14 @@ func (app *App) RunServer() error {
 			return nil
 		}
 		app.Logger.Info("Starting UDP DNS server", "port", app.DnsPort)
-		return (&dns.Server{
+		srv := &dns.Server{
 			Addr:    fmt.Sprintf(":%d", app.DnsPort),
 			Net:     "udp",
 			Handler: dns.HandlerFunc(dispatcher.HandleDNSRequest(forwarder.SourceUDP)),
-		}).ListenAndServe()
+		}
+
+		app.monitorShutdown(ctx, "UDP DNS server", srv.Shutdown)
+		return srv.ListenAndServe()
 	})
 
 	group.Go(func() error {
@@ -274,11 +291,14 @@ func (app *App) RunServer() error {
 			return nil
 		}
 		app.Logger.Info("Starting TCP DNS server", "port", app.DnsPort)
-		return (&dns.Server{
+		srv := &dns.Server{
 			Addr:    fmt.Sprintf(":%d", app.DnsPort),
 			Net:     "tcp",
 			Handler: dns.HandlerFunc(dispatcher.HandleDNSRequest(forwarder.SourceTCP)),
-		}).ListenAndServe()
+		}
+
+		app.monitorShutdown(ctx, "TCP DNS server", srv.Shutdown)
+		return srv.ListenAndServe()
 	})
 
 	group.Go(func() error {
@@ -311,12 +331,15 @@ func (app *App) RunServer() error {
 			})
 		}
 
-		return (&dns.Server{
+		srv := &dns.Server{
 			Addr:     dotPort,
 			Net:      "tcp",
 			Listener: listener,
 			Handler:  dns.HandlerFunc(dispatcher.HandleDNSRequest(forwarder.SourceDoT)),
-		}).ActivateAndServe()
+		}
+
+		app.monitorShutdown(ctx, "DoT server", srv.Shutdown)
+		return srv.ActivateAndServe()
 	})
 
 	return group.Wait()
@@ -454,4 +477,28 @@ func newStructuredLoggingConfig() *sloggin.Config {
 	config.Filters = append(config.Filters, sloggin.IgnorePath("/healthz", "/metrics"))
 
 	return &config
+}
+
+func (app *App) initIp2Location(crontab *cron.Cron) (geoblock.GeoIpLookup, error) {
+	geolocationDb := fmt.Sprintf("%s/ip2location/IP2LOCATION-LITE-DB1.BIN", app.DataDir)
+	if _, err := os.Stat(geolocationDb); os.IsNotExist(err) {
+		app.Logger.Info("Geolocation database not found, downloading...")
+		_, err = geoblock.Fetch("DB1LITEBIN", app.DataDir, app.Logger)
+		if err != nil {
+			return nil, errors.Wrap(err, "failed to download geoblock database")
+		}
+	}
+
+	app.Logger.Info("Loading geolocation database", "file", geolocationDb)
+	geoIpLookup, err := geoblock.NewGeoIpLookup(geolocationDb)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to open geoblock database")
+	}
+
+	app.Logger.Info("Creating IP2Location updater cron job", "schedule", app.CronSchedule.IP2Location)
+	if _, err = crontab.AddJob(app.CronSchedule.IP2Location, geoblock.NewIp2LocationUpdaterCronJob(app.Logger, "DB1LITEBIN", app.DataDir, geoIpLookup)); err != nil {
+		return nil, errors.Wrap(err, "failed to create IP2Location updater cron job")
+	}
+
+	return geoIpLookup, nil
 }

--- a/internal/downloader/download.go
+++ b/internal/downloader/download.go
@@ -14,12 +14,29 @@ import (
 	"github.com/dustin/go-humanize"
 )
 
+func isValidFile(uri string) (string, bool) {
+	u, err := url.Parse(uri)
+	if err != nil || u.Scheme != "file" {
+		return "", false
+	}
+
+	path := u.Path
+	if u.Host != "" && u.Host != "localhost" {
+		path = u.Host + path
+	}
+	return path, true
+}
+
 func isValidUrl(uri string) bool {
 	u, err := url.Parse(uri)
-	return err == nil && (u.Scheme == "http" || u.Scheme == "https")
+	return err == nil && (u.Scheme == "http" || u.Scheme == "https" || u.Scheme == "file")
 }
 
 func TransientDownload(logger *slog.Logger, purpose string, uri string, redact string, handler func(tmpfile string, header http.Header) error) error {
+	if path, ok := isValidFile(uri); ok {
+		return handler(path, http.Header{})
+	}
+
 	if !isValidUrl(uri) {
 		return handler(uri, http.Header{})
 	}

--- a/internal/forwarder/dispatcher.go
+++ b/internal/forwarder/dispatcher.go
@@ -18,7 +18,7 @@ import (
 )
 
 const (
-	NUM_WORKERS           = 4
+	NUM_WORKERS          = 4
 	SNAPSHOT_BUFFER_SIZE = 1024
 )
 
@@ -36,23 +36,23 @@ var (
 )
 
 type RequestContext struct {
-	ctx       context.Context
-	snapshot  *metrics.RequestSnapshot
-	logger    *slog.Logger
+	ctx      context.Context
+	snapshot *metrics.RequestSnapshot
+	logger   *slog.Logger
 }
 
 type DispatcherFunc func(writer dns.ResponseWriter, req *dns.Msg)
 
 type DNSDispatcher struct {
-	dnsClient   *RoundRobinClient
-	defaultTTL  float64
-	ttlFloor    time.Duration
-	cache       *DNSCache
-	blockList   *blocklist.BlockList
-	metrics     *metrics.DnsMetrics
-	logger      *slog.Logger
+	dnsClient  *RoundRobinClient
+	defaultTTL float64
+	ttlFloor   time.Duration
+	cache      *DNSCache
+	blockList  *blocklist.BlockList
+	metrics    *metrics.DnsMetrics
+	logger     *slog.Logger
 	snapshotCh chan *metrics.RequestSnapshot
-	done        chan struct{}
+	done       chan struct{}
 }
 
 func NewDNSDispatcher(
@@ -69,15 +69,15 @@ func NewDNSDispatcher(
 	}
 
 	d := &DNSDispatcher{
-		dnsClient:   dnsClient,
-		defaultTTL:  300, // TODO: pass in
-		ttlFloor:    ttlFloor,
-		cache:       cache,
-		blockList:   blockList,
-		metrics:     dnsMetrics,
-		logger:      logger,
+		dnsClient:  dnsClient,
+		defaultTTL: 300, // TODO: pass in
+		ttlFloor:   ttlFloor,
+		cache:      cache,
+		blockList:  blockList,
+		metrics:    dnsMetrics,
+		logger:     logger,
 		snapshotCh: make(chan *metrics.RequestSnapshot, SNAPSHOT_BUFFER_SIZE),
-		done:        make(chan struct{}),
+		done:       make(chan struct{}),
 	}
 
 	for range NUM_WORKERS {
@@ -124,8 +124,8 @@ func (d *DNSDispatcher) HandleDNSRequest(source DNSSource) DispatcherFunc {
 		defer span.End()
 
 		requestCtx := &RequestContext{
-			ctx:       ctx,
-			logger:    d.logger.With("client_ip", ipAddr, "request_id", req.Id, "source", source),
+			ctx:      ctx,
+			logger:   d.logger.With("client_ip", ipAddr, "request_id", req.Id, "source", source),
 			snapshot: metrics.NewRequestSnapshot(time.Now(), string(source), ipAddr),
 		}
 

--- a/internal/integration_test.go
+++ b/internal/integration_test.go
@@ -1,0 +1,154 @@
+package internal
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/miekg/dns"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestIntegration_DNSFunctionality(t *testing.T) {
+	// App configuration for integration test
+	app := App{
+		Logger:             slog.Default(),
+		DevMode:            true,
+		DnsPort:            8053,
+		DotPort:            8853,
+		HttpPort:           0, // Random port
+		Upstreams:          []string{"8.8.8.8", "1.1.1.1"},
+		BlockListURLs:      []string{"https://raw.githubusercontent.com/rm-hull/dot-block/refs/heads/main/data/blocklist.txt"},
+		AllowedHosts:       []string{"example.com"},
+		DataDir:            "../data",
+		DisableIp2Location: true,
+		MaxCacheSize:       1000,
+		CronSchedule: struct {
+			Downloader  string `json:"downloader"`
+			CacheReaper string `json:"cache_reaper"`
+			IP2Location string `json:"ip2location"`
+		}{
+			Downloader:  "@every 19h",
+			CacheReaper: "0 3 * * *",
+			IP2Location: "5 7 4 * *",
+		},
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	// RunServer will return when ctx is cancelled, but it starts multiple servers in a group.
+	// We need to run it in a goroutine.
+	go func() {
+		if err := app.RunServer(ctx); err != nil {
+			t.Errorf("RunServer failed: %v", err)
+		}
+	}()
+
+	// Wait for the server to start by polling the TCP port
+	start := time.Now()
+	for {
+		conn, err := net.DialTimeout("tcp", "127.0.0.1:8053", 100*time.Millisecond)
+		if err == nil {
+			conn.Close()
+			break
+		}
+		if time.Since(start) > 30*time.Second {
+			t.Fatal("Server failed to start within 30 seconds")
+		}
+		time.Sleep(500 * time.Millisecond)
+	}
+
+	tests := []struct {
+		name          string
+		protocol      string // "udp", "tcp", "dot"
+		port          int
+		domain        string
+		expectBlocked bool
+	}{
+		{
+			name:          "UDP - Good Domain",
+			protocol:      "udp",
+			port:          8053,
+			domain:        "google.com.",
+			expectBlocked: false,
+		},
+		{
+			name:          "UDP - Blocked Domain",
+			protocol:      "udp",
+			port:          8053,
+			domain:        "doubleclick.net.",
+			expectBlocked: true,
+		},
+		{
+			name:          "TCP - Good Domain",
+			protocol:      "tcp",
+			port:          8053,
+			domain:        "google.com.",
+			expectBlocked: false,
+		},
+		{
+			name:          "TCP - Blocked Domain",
+			protocol:      "tcp",
+			port:          8053,
+			domain:        "doubleclick.net.",
+			expectBlocked: true,
+		},
+		{
+			name:          "DoT (Plain) - Good Domain",
+			protocol:      "tcp",
+			port:          8853,
+			domain:        "google.com.",
+			expectBlocked: false,
+		},
+		{
+			name:          "DoT (Plain) - Blocked Domain",
+			protocol:      "tcp",
+			port:          8853,
+			domain:        "doubleclick.net.",
+			expectBlocked: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			msg := new(dns.Msg)
+			msg.SetQuestion(tt.domain, dns.TypeA)
+
+			var resp *dns.Msg
+			var err error
+
+			client := &dns.Client{
+				Net:     tt.protocol,
+				Timeout: 2 * time.Second,
+			}
+
+			addr := fmt.Sprintf("127.0.0.1:%d", tt.port)
+			resp, _, err = client.Exchange(msg, addr)
+
+			require.NoError(t, err, "DNS exchange failed")
+			require.NotNil(t, resp, "DNS response is nil")
+
+			if tt.expectBlocked {
+				// Based on internal/forwarder/dispatcher.go, blocked domains return a SOA record with ns.blocked.local.
+				foundBlockedSOA := false
+				for _, ans := range resp.Answer {
+					if soa, ok := ans.(*dns.SOA); ok {
+						if soa.Ns == "ns.blocked.local." {
+							foundBlockedSOA = true
+							break
+						}
+					}
+				}
+				assert.True(t, foundBlockedSOA, "Expected blocked SOA record for %s", tt.domain)
+			} else {
+				assert.Equal(t, dns.RcodeSuccess, resp.Rcode, "Expected NOERROR for %s", tt.domain)
+				assert.NotEmpty(t, resp.Answer, "Expected answers for %s", tt.domain)
+			}
+		})
+	}
+}

--- a/internal/integration_test.go
+++ b/internal/integration_test.go
@@ -43,24 +43,29 @@ func TestIntegration_DNSFunctionality(t *testing.T) {
 
 	// RunServer will return when ctx is cancelled, but it starts multiple servers in a group.
 	// We need to run it in a goroutine.
+	errCh := make(chan error, 1)
 	go func() {
-		if err := app.RunServer(ctx); err != nil {
-			t.Errorf("RunServer failed: %v", err)
-		}
+		errCh <- app.RunServer(ctx)
 	}()
 
 	// Wait for the server to start by polling the TCP port
 	start := time.Now()
 	for {
-		conn, err := net.DialTimeout("tcp", "127.0.0.1:8053", 100*time.Millisecond)
+		select {
+		case err := <-errCh:
+			t.Fatalf("RunServer exited unexpectedly: %v", err)
+		default:
+		}
+
+		conn, err := net.DialTimeout("tcp", "127.0.0.1:8053", 50*time.Millisecond)
 		if err == nil {
-			conn.Close()
+			_ = conn.Close()
 			break
 		}
-		if time.Since(start) > 30*time.Second {
-			t.Fatal("Server failed to start within 30 seconds")
+		if time.Since(start) > 5*time.Second {
+			t.Fatal("Server failed to start within 5 seconds")
 		}
-		time.Sleep(500 * time.Millisecond)
+		time.Sleep(100 * time.Millisecond)
 	}
 
 	tests := []struct {

--- a/internal/integration_test.go
+++ b/internal/integration_test.go
@@ -22,7 +22,7 @@ func TestIntegration_DNSFunctionality(t *testing.T) {
 		DotPort:            8853,
 		HttpPort:           0, // Random port
 		Upstreams:          []string{"8.8.8.8", "1.1.1.1"},
-		BlockListURLs:      []string{"https://raw.githubusercontent.com/rm-hull/dot-block/refs/heads/main/data/blocklist.txt"},
+		BlockListURLs:      []string{"file://../data/blocklist.txt"},
 		AllowedHosts:       []string{"example.com"},
 		DataDir:            "../data",
 		DisableIp2Location: true,

--- a/internal/metrics/request_snapshot.go
+++ b/internal/metrics/request_snapshot.go
@@ -97,8 +97,10 @@ func (t *RequestSnapshot) Record(metrics *DnsMetrics) {
 		metrics.TopClients.Add(t.ipAddr)
 		metrics.UniqueClients.Insert([]byte(t.ipAddr))
 
-		if record, err := metrics.geoIpLookup.GetAll(t.ipAddr); err == nil && record.Country_short != "" {
-			metrics.CountryCounts.WithLabelValues(record.Country_short).Inc()
+		if metrics.geoIpLookup != nil {
+			if record, err := metrics.geoIpLookup.GetAll(t.ipAddr); err == nil && record.Country_short != "" {
+				metrics.CountryCounts.WithLabelValues(record.Country_short).Inc()
+			}
 		}
 	}
 

--- a/internal/telemetry/telemetry_test.go
+++ b/internal/telemetry/telemetry_test.go
@@ -35,16 +35,16 @@ func TestInitTracer_WithEndpoint(t *testing.T) {
 	var buf bytes.Buffer
 	logger := slog.New(slog.NewTextHandler(&buf, nil))
 
-	// This might fail because it tries to create a gRPC connection, 
+	// This might fail because it tries to create a gRPC connection,
 	// but we just want to check it doesn't return the no-op immediately.
 	shutdown, err := InitTracer(logger, "test-service")
-	
-	// It might error if gRPC fails to init (e.g. network), but it should NOT 
+
+	// It might error if gRPC fails to init (e.g. network), but it should NOT
 	// return the no-op if endpoint is set.
 	if err == nil {
 		assert.NotNil(t, shutdown)
 		_ = shutdown(context.Background())
-		
+
 		assert.Contains(t, buf.String(), "level=INFO")
 		assert.Contains(t, buf.String(), "OTEL tracing initialized")
 	}

--- a/main.go
+++ b/main.go
@@ -4,7 +4,9 @@ import (
 	"context"
 	"log/slog"
 	"os"
+	"os/signal"
 	"strings"
+	"syscall"
 	"time"
 
 	"github.com/rm-hull/dot-block/internal"
@@ -81,7 +83,10 @@ func main() {
 				app.Logger.Warn("Running in DEV MODE: TLS disabled, using non-privileged ports")
 			}
 
-			return app.RunServer(context.Background())
+			ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+			defer stop()
+
+			return app.RunServer(ctx)
 		},
 	}
 

--- a/main.go
+++ b/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"log/slog"
 	"os"
 	"strings"
@@ -80,7 +81,7 @@ func main() {
 				app.Logger.Warn("Running in DEV MODE: TLS disabled, using non-privileged ports")
 			}
 
-			return app.RunServer()
+			return app.RunServer(context.Background())
 		},
 	}
 


### PR DESCRIPTION
This PR introduces several improvements to server lifecycle management, configuration flexibility, and testing.

### Changes

- **Graceful Shutdown**:
    - Updated `RunServer` to accept `context.Context`.
    - Implemented `monitorShutdown` to ensure HTTP, UDP DNS, TCP DNS, and DoT servers shut down cleanly.
    - Integrated `signal.NotifyContext` in `main.go` to trigger shutdown on `SIGINT`/`SIGTERM`.
    - Switched to `errgroup.WithContext` for better group lifecycle management.

- **Optional IP2Location**:
    - Added `DisableIp2Location` configuration flag.
    - Refactored IP2Location initialization into a dedicated method.
    - Added safety checks in metrics recording to handle disabled geolocation.

- **Local Blocklist Support**:
    - Added support for `file://` URIs in blocklists, allowing local files to be used as sources.

- **Integration Testing**:
    - Added `internal/integration_test.go` which performs end-to-end tests of the server's DNS functionality across UDP, TCP, and DoT (plain) protocols.

- **General Cleanup**:
    - Various formatting and alignment fixes.
