### PR TITLE
refactor: switch from TCP to UDP for DNS upstream communication

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,23 @@ The easiest way to get started with DoT Block is to use Docker and Docker Compos
 
 The server will be accessible at `dot.your-domain.com`.
 
+#### Production Tuning
+
+For high-traffic environments, you may need to tune the network stack to avoid port exhaustion and packet loss. You can apply these settings directly in your `docker-compose.yml` using `sysctls`:
+
+```yaml
+services:
+  dot-block:
+    # ... other configuration ...
+    sysctls:
+      - net.ipv4.ip_local_port_range=1024 65535
+      - net.core.rmem_max=26214400
+      - net.core.wmem_max=26214400
+```
+
+- `net.ipv4.ip_local_port_range`: Expands the ephemeral port range to allow more concurrent outgoing UDP requests.
+- `net.core.rmem_max` & `net.core.wmem_max`: Increases the maximum OS receive and send buffer sizes for UDP to prevent packet drops during traffic spikes.
+
 ### Local Development
 
 For local development, you can run the server in "dev mode", which uses plain TCP instead of TLS.
@@ -136,7 +153,6 @@ DoT Block can be configured using the following command-line flags:
 | `--allowed-hosts` | List of domains used for the CertManager allow policy. | `nil` |
 | `--blocklist-url` | List of URL blocklists (wildcard hostname format). | `https://codeberg.org/hagezi/mirror2/raw/branch/main/dns-blocklists/hosts/pro.txt`, `https://raw.githubusercontent.com/rm-hull/dot-block/refs/heads/main/data/blocklist.txt` |
 | `--cache-ttl-floor` | Minimum TTL for cached entries (in seconds). If a response is not "freshness sensitive" (e.g. contains `ocsp`, `crl`, `pki` or is `SOA`/`TXT`), the cache TTL will be at least this value. | `3600s` |
-| `--connection-pool-size` | Number of connections to maintain in pool for each upstream server | `10` |
 | `--dial-timeout` | Timeout for establishing TCP connections to upstream servers | `300ms` |
 | `--read-timeout` | Timeout for waiting for responses from upstream DNS servers | `300ms` |
 | `--write-timeout` | Timeout for writing upstream DNS queries | `100ms` |

--- a/docs/errors/timeout1.json
+++ b/docs/errors/timeout1.json
@@ -1,0 +1,12 @@
+{
+    "time": "2026-06-06T10:12:31.760937214+01:00",
+    "level": "ERROR",
+    "msg": "DNS error",
+    "client_ip": "172.18.0.33",
+    "request_id": 30463,
+    "source": "UDP",
+    "qtype": "A",
+    "category": "upstream",
+    "error": "all upstream servers failed: upstream 8.8.8.8:53 failed: read tcp 172.18.0.7:53208 -> 8.8.8.8:53: i/o timeout",
+    "stack_trace": "all upstream servers failed: upstream 8.8.8.8:53 failed: read tcp 172.18.0.7:53208 -> 8.8.8.8:53: i/o timeout\n(1) attached stack trace\n  -- stack trace:\n  | github.com/rm-hull/dot-block/internal/forwarder.(*RoundRobinClient).Exchange\n  | \t/app/internal/forwarder/round_robin_client.go:150\n  | [...repeated from below...]\nWraps: (2) all upstream servers failed\nWraps: (3) attached stack trace\n  -- stack trace:\n  | github.com/rm-hull/dot-block/internal/forwarder.(*RoundRobinClient).Exchange\n  | \t/app/internal/forwarder/round_robin_client.go:148\n  | github.com/rm-hull/dot-block/internal/forwarder.(*DNSDispatcher).forwardQuery\n  | \t/app/internal/forwarder/dispatcher.go:317\n  | github.com/rm-hull/dot-block/internal/forwarder.(*DNSDispatcher).resolveUpstream\n  | \t/app/internal/forwarder/dispatcher.go:245\n  | github.com/rm-hull/dot-block/internal.(*App).RunServer.func2.(*DNSDispatcher).HandleDNSRequest.1\n  | \t/app/internal/forwarder/dispatcher.go:138\n  | github.com/miekg/dns.HandlerFunc.ServeDNS\n  | \t/go/pkg/mod/github.com/miekg/dns@v1.1.72/server.go:37\n  | github.com/miekg/dns.(*Server).serveDNS\n  | \t/go/pkg/mod/github.com/miekg/dns@v1.1.72/server.go:683\n  | github.com/miekg/dns.(*Server).serveUDPPacket\n  | \t/go/pkg/mod/github.com/miekg/dns@v1.1.72/server.go:624\n  | runtime.goexit\n  | \t/usr/local/go/src/runtime/asm_amd64.s:1771\nWraps: (4) upstream 8.8.8.8:53 failed\nWraps: (5) read tcp 172.18.0.7:53208 -> 8.8.8.8:53\nWraps: (6) i/o timeout\nError types: (1) *withstack.withStack (2) *errutil.withPrefix (3) *withstack.withStack (4) *errutil.withPrefix (5) *net.OpError (6) *poll.DeadlineExceededError"
+}

--- a/docs/errors/timeout2.json
+++ b/docs/errors/timeout2.json
@@ -1,0 +1,11 @@
+{
+    "time": "2026-06-06T10:12:34.322115912+01:00",
+    "level": "ERROR",
+    "msg": "DNS error",
+    "client_ip": "172.18.0.33",
+    "request_id": 30463,
+    "source": "UDP",
+    "qtype": "A",
+    "category": "upstream",
+    "error": "upstream resolver (1.1.1.1:53) returned Rcode: SERVFAIL for query: chatwoodbeply.beply.com."
+}

--- a/docs/evaluating-udp.md
+++ b/docs/evaluating-udp.md
@@ -1,0 +1,59 @@
+# Evaluating UDP Performance: Simple vs. Optimized
+
+This document provides a guide on how to use the existing observability stack (Prometheus, Logs, and OpenTelemetry) to determine if the "Simple" UDP implementation (`miekg/dns.Client.Exchange`) is creating a performance bottleneck.
+
+## Goal
+Determine if the overhead of creating a new socket for every DNS query is significantly impacting latency or CPU utilization, and whether it is causing stability issues under load.
+
+## 1. Prometheus Metrics
+Prometheus provides the aggregate view. Look for correlations between request volume (QPS) and error rates.
+
+### Key Metrics to Monitor:
+- **Upstream Failure Rate:** 
+    - Monitor `dns_upstream_failures_total` grouped by `upstream` and `reason`.
+    - **Red Flag:** A spike in `network_error` or `timeout` reasons that correlates with increased QPS. This suggests the kernel is struggling to allocate sockets or handle the churn rate.
+- **Request Latency:** 
+    - Analyze the latency of requests that hit the upstream.
+    - **Red Flag:** A steady increase in p99 latency as QPS increases, even if the upstream server's own response time remains constant.
+
+## 2. OpenTelemetry (OTel) Tracing
+Tracing allows us to see the "anatomy" of a single request.
+
+### What to Look For:
+- **Span Analysis:** Examine the span associated with the upstream DNS exchange.
+- **Latency Breakdown:**
+    - The span covers the time from `Exchange` start to finish. This includes:
+        - `Socket creation` $\rightarrow$ `Packet send` $\rightarrow$ `Network Transit` $\rightarrow$ `Upstream Processing` $\rightarrow$ `Packet return`.
+    - **Red Flag:** If you compare traces from a low-load period to a high-load period and see the "Upstream" span duration increasing significantly while the upstream server is healthy, the overhead is likely in the local socket management.
+
+## 3. Log Analysis
+Logs capture the specific errors that metrics might aggregate.
+
+### Search Terms:
+- Search for "upstream failure" or "network error".
+- **Red Flag:** Errors like `cannot assign requested address` or `too many open files`. These are definitive indicators of ephemeral port exhaustion or file descriptor limits being hit due to high socket churn.
+
+## 4. System-Level Observations (External to App)
+Since the app only sees the *result* of a socket call, use OS tools to see the *cause*.
+
+### Resource Monitoring:
+- **CPU Utilization (`top` / `htop`):**
+    - Check for high `%sys` (system) CPU usage. High system time relative to user time often indicates excessive system calls (like `socket()` and `close()`).
+- **Socket State (`ss`):**
+    - Run `ss -u -a` during a load test.
+    - While UDP is stateless, checking the number of active sockets can reveal if the app is holding onto resources longer than expected.
+- **Kernel Profiling (`perf`):**
+    - Use `perf top` to see which kernel functions are consuming the most CPU.
+    - **Red Flag:** High percentages in `tcp_v4_connect` (even for UDP if using `Dial`) or `unix_stream_connect` / `socket_create`.
+
+## Decision Matrix: When to Optimize?
+
+| Observation | Simple Solution is OK | Optimize to Persistent Sockets |
+| :--- | :--- | :--- |
+| **CPU Usage** | Low/Moderate `%sys` | High `%sys` during QPS spikes |
+| **Latency** | Stable p99 regardless of load | p99 increases linearly with load |
+| **Errors** | No network-level errors | `EADDRNOTAVAIL` or frequent `network_error` |
+| **Scale** | < 1k QPS | > 5k QPS or strict latency requirements |
+
+## Testing Strategy
+To actually trigger these bottlenecks, run a load test using a tool like `dnsperf` or `flamethrower` against the server, gradually increasing the request rate until the "Red Flags" appear.

--- a/docs/load-testing.md
+++ b/docs/load-testing.md
@@ -1,0 +1,111 @@
+# Load Testing the DNS Server
+
+This document describes how to use `dnsperf` and `flamethrower` to stress test the DoT Block server and evaluate its performance.
+
+## Testing Environment
+To avoid network bottlenecks and latency noise, it is recommended to run the load testing tool on the same host or within the same Docker network as the server.
+
+**Target:**
+- **UDP Server (Dev Mode):** `127.0.0.1:8053`
+- **Production Server:** `<your-server-ip>:53` (or 853 for DoT, though these tools primarily test UDP/TCP)
+
+---
+
+## 1. Using `dnsperf`
+
+`dnsperf` is a classic tool for measuring the performance of DNS servers. It allows you to send a predefined list of queries and measures the response rate and latency.
+
+### Installation
+On macOS (via Homebrew):
+```bash
+brew install dnsperf
+```
+On Linux (Ubuntu/Debian):
+```bash
+sudo apt-get install dnsperf
+```
+
+### Usage
+`dnsperf` requires a "query file" containing the domains you want to resolve.
+
+#### Step 1: Create a query file (`queries.txt`)
+Format: `domain type`
+```text
+google.com A
+example.com A
+microsoft.com A
+github.com A
+apple.com A
+```
+
+#### Step 2: Run the test
+```bash
+# -s: Server IP
+# -p: Port
+# -d: Query file
+# -l: Duration in seconds
+# -c: Number of concurrent clients
+dnsperf -s 127.0.0.1 -p 8053 -d queries.txt -l 60 -c 20
+```
+
+---
+
+## 2. Using `flame` (Flamethrower)
+
+`flame` (by DNS-OARC) is a high-performance C++ DNS stress testing tool. It is extremely efficient and capable of saturating a network link or CPU to evaluate how a server handles extreme load.
+
+### Installation
+The easiest way to run `flame` is via Docker:
+```bash
+docker pull ns1labs/flame
+# Run help to verify
+docker run --rm ns1labs/flame --help
+```
+
+### Usage
+The basic syntax is `flame <target> [options]`.
+
+#### Random Query Stress Test
+To test the "Simple" UDP implementation without cache interference, use the `randomlabel` generator. This ensures the server must perform an upstream exchange for every request.
+
+```bash
+# Target: 127.0.0.1, Port: 8053
+# -p: Port
+# -Q: Rate of queries per second (QPS)
+# -c: Number of concurrent senders
+# -g: Generator (randomlabel) with options (label size, count, and total queries)
+docker run --rm --net host ns1labs/flame 127.0.0.1 -p 8053 -Q 1000 -c 10 -g randomlabel lblsize=10 lblcount=4 count=10000
+```
+
+#### Custom Query List
+`flame` primarily uses generators. To use a specific list of queries, check `flame --help` for the `file` generator options.
+
+#### Testing Other Protocols (TCP/DoT)
+`flame` can also test the TCP and DoT interfaces:
+```bash
+# TCP
+docker run --rm --net host ns1labs/flame 127.0.0.1 -p 8053 -P tcp
+
+# DoT
+docker run --rm --net host ns1labs/flame 127.0.0.1 -p 8853 -P dot
+```
+
+---
+
+## Correlation with Observability
+
+While running these tests, you should monitor the indicators defined in [evaluating-udp.md](evaluating-udp.md).
+
+### Scenario A: Validating the "Simple" Solution
+1. Start `flame` at 100 QPS.
+2. Check Prometheus: `dns_upstream_failures_total` should be 0.
+3. Check `htop`: `%sys` CPU should be negligible.
+4. Gradually increase QPS to 1k, 5k, 10k.
+5. **The "Breaking Point":** Note the QPS at which you see `network_error` in logs or a sharp spike in `%sys` CPU.
+
+### Scenario B: Verifying the Optimization (after implementing Persistent Sockets)
+1. Run the same test at the previous "Breaking Point" RPS.
+2. **Expected Result:**
+    - `%sys` CPU should be significantly lower.
+    - p99 latency should be lower and more stable.
+    - No `EADDRNOTAVAIL` or `network_error` related to socket churn.

--- a/docs/performance-baseline-tcp.md
+++ b/docs/performance-baseline-tcp.md
@@ -1,0 +1,54 @@
+# Performance Baseline: TCP Connection Pooling (Main Branch)
+
+This document summarizes the performance of the DNS forwarder using the TCP connection pooling implementation found on the `main` branch.
+
+## Test Configuration
+- **Tool:** `flame` (DNS-OARC)
+- **Target:** `dns.hz-nbg1.destructuring-bind.org:1053`
+- **Query Type:** `randomlabel` (Bypasses cache, forcing upstream exchange for every request)
+- **Concurrency:** 10 concurrent senders
+
+**Commands used:**
+```bash
+# 100 QPS
+docker run --rm --net host ns1labs/flame dns.hz-nbg1.destructuring-bind.org -p 1053 -Q 100 -c 10 -g randomlabel lblsize=10 lblcount=4 count=100
+
+# 1000 QPS
+docker run --rm --net host ns1labs/flame dns.hz-nbg1.destructuring-bind.org -p 1053 -Q 1000 -c 10 -g randomlabel lblsize=10 lblcount=4 count=10
+```
+
+## Test Results
+
+| Metric | 100 QPS | 1000 QPS |
+| :--- | :--- | :--- |
+| **Duration** | ~100s | ~34s |
+| **Total Sent** | 10,070 | 31,070 |
+| **Total Received** | 10,070 | 31,070 |
+| **Success Rate** | 100% | 100% |
+| **Timeouts** | 0 (0%) | 0 (0%) |
+| **Network Errors** | 0 | 0 |
+| **Min Response Time** | 30.26 ms | 27.98 ms |
+| **Avg Response Time** | 280.82 ms | 155.50 ms |
+| **Max Response Time** | 798.13 ms | 942.58 ms |
+| **Avg Send QPS** | 96 | 964 |
+| **Avg Recv QPS** | 93 | 960 |
+
+## Analysis
+
+### 1. Stability
+The system is remarkably stable even at 1000 QPS. There were **zero timeouts** and **zero network errors**, indicating that the TCP connection pool is successfully managing upstream connections without exhaustion or crash.
+
+### 2. Latency Trends
+- At 100 QPS, avg latency was **~281ms**.
+- At 1000 QPS, avg latency dropped to **~156ms**.
+- This decrease in average latency at higher load is likely due to the `randomlabel` generator distribution or upstream server behavior (e.g., some responses arriving faster as the pipe fills), rather than local server overhead.
+- The minimum response (~28-30ms) remains constant, confirming the baseline network latency.
+
+### 3. Resource Utilization (Little's Law)
+For the 1000 QPS test:
+$$\text{In Flight} = \text{Arrival Rate} \times \text{Average Latency}$$
+$$1000\text{ QPS} \times 0.155\text{s} \approx 155\text{ requests in flight}$$
+The `flame` output showed "in flight" counts ranging from ~110 to ~300, which aligns well with the theoretical expectation.
+
+## Conclusion
+The TCP connection pooling implementation handles 1000 QPS with ease. It maintains 100% reliability and consistent latency. This provides a strong benchmark: any new UDP implementation must at least match this stability and throughput.

--- a/docs/udp-optimization.md
+++ b/docs/udp-optimization.md
@@ -1,0 +1,68 @@
+# UDP Upstream Communication Optimization
+
+## Overview
+The current implementation of `RoundRobinClient` uses `miekg/dns.Client.Exchange` for communicating with upstream DNS servers. While simple and thread-safe, this approach may introduce performance bottlenecks at high request volumes.
+
+## The Problem
+The `Exchange` method in the `miekg/dns` library is a high-level convenience function. For every call, it performs the following sequence:
+1. `net.Dial` (creates a new socket)
+2. `Write` (sends the DNS query)
+3. `Read` (waits for the response)
+4. `Close` (destroys the socket)
+
+### Technical Impact
+- **CPU Overhead:** Each query triggers multiple system calls (`socket`, `connect`, `sendto`, `recvfrom`, `close`). At thousands of queries per second, this adds significant CPU load.
+- **Latency:** The overhead of socket creation and destruction adds a small but constant latency penalty to every request.
+- **Socket Churn:** While UDP doesn't suffer from TCP's `TIME_WAIT` state, the high rate of socket creation can still put pressure on the OS kernel and potentially hit limits on the rate of ephemeral port allocation.
+
+## Options for Improvement
+
+### Option 1: Maintain Current "Simple" Approach
+Continue using `Exchange`.
+- **Pros:** 
+    - Extremely simple implementation.
+    - No need to manage state or match responses to requests.
+    - Native thread-safety provided by the library.
+- **Cons:** 
+    - Suboptimal CPU usage.
+    - Higher latency than persistent connections.
+
+### Option 2: Persistent Sockets with Response Dispatcher (Industrial Approach)
+Establish one persistent `net.UDPConn` per upstream server.
+- **Implementation:**
+    - Create a long-lived UDP socket for each upstream.
+    - Implement a background **Dispatcher** goroutine that continuously reads from the socket.
+    - Use the **DNS Transaction ID (TXID)** to match incoming responses to the original waiting requests using a concurrency-safe map of channels.
+- **Pros:** 
+    - Maximum performance and lowest latency.
+    - Minimal system call overhead.
+- **Cons:** 
+    - Significant increase in complexity.
+    - Must handle TXID collisions and timeout management manually.
+
+### Option 3: Socket Pooling (Middle Ground)
+Maintain a small pool of pre-allocated sockets per upstream.
+- **Implementation:**
+    - A pool (e.g., 10-50 sockets) is maintained for each upstream.
+    - Requests lease a socket, use it for one exchange, and return it.
+- **Pros:** 
+    - Reduces socket churn and CPU overhead compared to Option 1.
+    - Simpler than implementing a full dispatcher.
+- **Cons:** 
+    - Risk of pool exhaustion under extreme load.
+    - Still involves some management overhead.
+
+## Investigation Plan
+To determine if the "Simple" solution is sufficient, we will perform a benchmark test:
+1. **Load Test:** Generate a high volume of DNS queries (e.g., 1k-10k QPS).
+2. **Metrics Collection:**
+    - Monitor CPU utilization of the `dot-block` process.
+    - Measure p99 latency of upstream requests.
+    - Monitor system-level socket creation rates using `ss` or `netstat`.
+3. **Analysis:** Compare results against the available hardware resources to see if the overhead is actually a bottleneck for the target use case.
+
+## Implementation Notes (for Option 2)
+If Option 2 is chosen:
+- Use a `map[uint16]chan *dns.Msg` for the registry.
+- Ensure a `sync.Mutex` or `sync.Map` protects the registry.
+- Implement a "reaper" or use `time.After` on the channels to prevent memory leaks from unanswered queries.

--- a/internal/app.go
+++ b/internal/app.go
@@ -60,7 +60,6 @@ type App struct {
 		IP2Location string `json:"ip2location"`
 	} `json:"cron_schedule"`
 	CacheTtlFloor        time.Duration `json:"cache_ttl_floor"`
-	ConnectionPoolSize   int           `json:"connection_pool_size"`
 	RequireProxyProtocol bool          `json:"require_proxy_protocol"`
 	TrustedProxies       []string      `json:"trusted_proxies,omitempty"`
 	Timeouts             struct {
@@ -74,34 +73,27 @@ type App struct {
 func (app *App) LogValue() slog.Value {
 	return slog.AnyValue(structToMap(app))
 }
-
 func structToMap(obj any) any {
 	v := reflect.ValueOf(obj)
 	if v.Kind() == reflect.Pointer {
 		v = v.Elem()
 	}
-
 	if v.Kind() != reflect.Struct {
 		return obj
 	}
-
 	m := make(map[string]any)
 	t := v.Type()
-
 	for i := 0; i < t.NumField(); i++ {
 		field := t.Field(i)
 		tag := field.Tag.Get("json")
 		if tag == "-" {
 			continue
 		}
-
 		name := field.Name
 		if tag != "" {
 			name = strings.Split(tag, ",")[0]
 		}
-
 		val := v.Field(i).Interface()
-
 		// If the field is a struct (and not time.Time), recursively convert it to a map
 		// so that ReplaceAttr can recurse into it.
 		if reflect.TypeOf(val).Kind() == reflect.Struct && reflect.TypeOf(val) != reflect.TypeFor[time.Time]() {
@@ -110,10 +102,8 @@ func structToMap(obj any) any {
 			m[name] = val
 		}
 	}
-
 	return m
 }
-
 func (app *App) monitorShutdown(ctx context.Context, name string, shutdownFn func() error) {
 	go func() {
 		<-ctx.Done()
@@ -124,14 +114,12 @@ func (app *App) monitorShutdown(ctx context.Context, name string, shutdownFn fun
 		}
 	}()
 }
-
 func (app *App) RunServer(ctx context.Context) error {
 	if err := godotenv.Load(); err != nil {
 		app.Logger.Warn("No .env file found")
 	}
 	godx.Diagnostics(app.Logger)
 	app.Logger.Info("Configuation on startup", "app", app)
-
 	shutdownTracer, err := telemetry.InitTracer(app.Logger, "dot-block")
 	if err != nil {
 		app.Logger.Error("failed to initialize tracing", "error", err)
@@ -144,7 +132,6 @@ func (app *App) RunServer(ctx context.Context) error {
 			}
 		}()
 	}
-
 	err = sentry.Init(sentry.ClientOptions{
 		Dsn:         os.Getenv("SENTRY_DSN"),
 		Debug:       app.DevMode,
@@ -155,12 +142,10 @@ func (app *App) RunServer(ctx context.Context) error {
 		app.Logger.Error("sentry.Init failed", "error", err)
 	}
 	defer sentry.Flush(2 * time.Second)
-
 	adapter := logging.NewCronLoggerAdapter(app.Logger, "cron")
 	crontab := cron.New(cron.WithChain(cron.Recover(adapter)), cron.WithLogger(adapter))
 	crontab.Start()
 	defer crontab.Stop()
-
 	var geoIpLookup geoblock.GeoIpLookup
 	if app.DisableIp2Location {
 		app.Logger.Warn("IP2Location lookups are disabled")
@@ -170,30 +155,24 @@ func (app *App) RunServer(ctx context.Context) error {
 			return errors.Wrap(err, "failed to initialize IP2Location")
 		}
 	}
-
 	allHosts := make([]string, 0)
 	for _, url := range app.BlockListURLs {
 		hosts, err := blocklist.Fetch(url, app.Logger)
 		if err != nil {
 			return errors.Wrapf(err, "failed to download blocklist: %s", url)
 		}
-
 		allHosts = append(allHosts, hosts...)
 	}
-
 	blockList := blocklist.NewBlockList(allHosts, 0.0001, app.Logger)
-
 	app.Logger.Info("Creating blocklist downloader cron job", "schedule", app.CronSchedule.Downloader)
 	blocklistUpdater := blocklist.NewBlocklistUpdater(blockList, app.BlockListURLs)
 	if _, err = crontab.AddJob(app.CronSchedule.Downloader, blocklistUpdater); err != nil {
 		return errors.Wrap(err, "failed to create blocklist downloader cron job")
 	}
-
 	certCacheDir := fmt.Sprintf("%s/certcache", app.DataDir)
 	if err := os.MkdirAll(certCacheDir, 0700); err != nil {
 		return errors.Wrap(err, "failed to create certcache directory")
 	}
-
 	// certmagic setup
 	zapLogger := logging.NewZapLoggerAdapter(app.Logger, "certmagic")
 	certmagic.Default.Logger = zapLogger
@@ -201,15 +180,12 @@ func (app *App) RunServer(ctx context.Context) error {
 	certmagic.DefaultACME.Agreed = true
 	certmagic.DefaultACME.Email = os.Getenv("ACME_EMAIL")
 	certmagic.Default.Storage = &certmagic.FileStorage{Path: certCacheDir}
-
 	var magic *certmagic.Config
-
 	if !app.DevMode {
 		token := os.Getenv("CLOUDFLARE_API_TOKEN")
 		if token == "" {
 			return errors.New("CLOUDFLARE_API_TOKEN environment variable is required for DNS-01 challenge")
 		}
-
 		certmagic.DefaultACME.DNS01Solver = &certmagic.DNS01Solver{
 			DNSManager: certmagic.DNSManager{
 				DNSProvider: &cloudflare.Provider{
@@ -217,60 +193,50 @@ func (app *App) RunServer(ctx context.Context) error {
 				},
 			},
 		}
-
 		magic = certmagic.NewDefault()
 		if err := magic.ManageSync(context.Background(), app.AllowedHosts); err != nil {
 			return errors.Wrap(err, "failed to manage certificates")
 		}
 	}
-
 	cache := forwarder.NewDNSCache(app.MaxCacheSize, app.Logger)
 	metrics, err := metrics.NewDNSMetrics(cache, geoIpLookup)
 	if err != nil {
 		return errors.Wrap(err, "failed to initialize metrics")
 	}
-	dnsClient, err := forwarder.NewRoundRobinClient(metrics, app.Timeouts.Read, app.Timeouts.Write, app.Timeouts.Dial, app.ConnectionPoolSize, app.Logger, app.Upstreams...)
+	dnsClient, err := forwarder.NewRoundRobinClient(metrics, app.Timeouts.Read, app.Timeouts.Write, app.Timeouts.Dial, app.Logger, app.Upstreams...)
 	if err != nil {
 		return errors.Wrap(err, "failed to initialize upstream DNS client")
 	}
-
 	r, err := app.startHttpServer(dnsClient, blocklistUpdater)
 	if err != nil {
 		return errors.Wrap(err, "failed to initialize HTTP server")
 	}
-
 	dispatcher, err := forwarder.NewDNSDispatcher(cache, metrics, dnsClient, blockList, app.CacheTtlFloor, app.Logger)
 	if err != nil {
 		return errors.Wrap(err, "failed to create dispatcher")
 	}
 	defer dispatcher.Close()
-
 	app.Logger.Info("Creating cache reaper cron job", "schedule", app.CronSchedule.CacheReaper)
 	if _, err = crontab.AddJob(app.CronSchedule.CacheReaper, forwarder.NewCacheReaperCronJob(dispatcher)); err != nil {
 		return errors.Wrap(err, "failed to create cache reaper cron job")
 	}
-
 	group, groupCtx := errgroup.WithContext(ctx)
-
 	group.Go(func() error {
 		app.Logger.Info("Starting HTTP server for mobileconfig, metrics & healthcheck", "port", app.HttpPort)
 		srv := &http.Server{
 			Addr:    fmt.Sprintf(":%d", app.HttpPort),
 			Handler: r,
 		}
-
 		app.monitorShutdown(groupCtx, "HTTP server", func() error {
 			shutdownCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 			defer cancel()
 			return srv.Shutdown(shutdownCtx)
 		})
-
 		if err := srv.ListenAndServe(); err != nil && err != http.ErrServerClosed {
 			return errors.Wrap(err, "HTTP server failed")
 		}
 		return nil
 	})
-
 	group.Go(func() error {
 		if app.DnsPort == 0 {
 			app.Logger.Warn("Skipping UDP DNS server: dns-port not specified")
@@ -282,11 +248,9 @@ func (app *App) RunServer(ctx context.Context) error {
 			Net:     "udp",
 			Handler: dns.HandlerFunc(dispatcher.HandleDNSRequest(forwarder.SourceUDP)),
 		}
-
 		app.monitorShutdown(groupCtx, "UDP DNS server", srv.Shutdown)
 		return srv.ListenAndServe()
 	})
-
 	group.Go(func() error {
 		if app.DnsPort == 0 {
 			app.Logger.Warn("Skipping TCP DNS server: dns-port not specified")
@@ -298,11 +262,9 @@ func (app *App) RunServer(ctx context.Context) error {
 			Net:     "tcp",
 			Handler: dns.HandlerFunc(dispatcher.HandleDNSRequest(forwarder.SourceTCP)),
 		}
-
 		app.monitorShutdown(groupCtx, "TCP DNS server", srv.Shutdown)
 		return srv.ListenAndServe()
 	})
-
 	group.Go(func() error {
 		dotPort := fmt.Sprintf(":%d", app.DotPort)
 		listener, err := net.Listen("tcp", dotPort)
@@ -315,38 +277,31 @@ func (app *App) RunServer(ctx context.Context) error {
 				app.Logger.Warn("error closing DoT listener", "error", err)
 			}
 		}()
-
 		if app.DevMode {
 			app.Logger.Info("Starting DoT server (plain TCP) in DEV mode", "port", app.DotPort)
 		} else {
 			app.Logger.Info("Starting DNS-over-TLS server", "port", app.DotPort)
-
 			proxyListener, err := app.newProxyListener(listener)
 			if err != nil {
 				return err
 			}
-
 			listener = tls.NewListener(proxyListener, &tls.Config{
 				MinVersion:     tls.VersionTLS12,
 				NextProtos:     []string{"dot"},
 				GetCertificate: magic.GetCertificate,
 			})
 		}
-
 		srv := &dns.Server{
 			Addr:     dotPort,
 			Net:      "tcp",
 			Listener: listener,
 			Handler:  dns.HandlerFunc(dispatcher.HandleDNSRequest(forwarder.SourceDoT)),
 		}
-
 		app.monitorShutdown(groupCtx, "DoT server", srv.Shutdown)
 		return srv.ActivateAndServe()
 	})
-
 	return group.Wait()
 }
-
 func (app *App) newProxyListener(base net.Listener) (*proxyproto.Listener, error) {
 	var proxyListener *proxyproto.Listener
 	if len(app.TrustedProxies) > 0 {
@@ -380,25 +335,20 @@ func (app *App) newProxyListener(base net.Listener) (*proxyproto.Listener, error
 	}
 	return proxyListener, nil
 }
-
 func (app *App) startHttpServer(dnsClient *forwarder.RoundRobinClient, blocklistUpdater *blocklist.BlocklistUpdater) (*gin.Engine, error) {
 	if !app.DevMode {
 		gin.SetMode(gin.ReleaseMode)
 	}
-
 	r := gin.New()
 	blocklistHandler := routes.NewBlocklistHandler(blocklistUpdater, app.Logger)
-
 	if app.DevMode {
 		app.Logger.Warn("pprof endpoints are enabled and exposed. Do not run with this flag in production.")
 		pprof.Register(r)
 	}
-
 	prometheus := ginprom.New(
 		ginprom.Path("/metrics"),
 		ginprom.Ignore("/healthz", "/metrics"),
 	)
-
 	r.Use(
 		sentrygin.New(sentrygin.Options{
 			Repanic:         true,
@@ -410,16 +360,13 @@ func (app *App) startHttpServer(dnsClient *forwarder.RoundRobinClient, blocklist
 		prometheus.Instrument(),
 		routes.SentryErrorHandler(app.Logger),
 	)
-
 	if err := healthcheck.New(r, hc_config.DefaultConfig(), dnsClient.Healthchecks()); err != nil {
 		return nil, errors.Wrap(err, "failed to initialize healthcheck")
 	}
-
 	if app.MetricsAuth == "" {
 		app.Logger.Warn("Metrics & reload endpoints are not protected by basic auth")
 		r.GET("/metrics", gin.WrapH(promhttp.Handler()))
 		r.GET("/reload", blocklistHandler.Reload)
-
 	} else {
 		parts := strings.SplitN(app.MetricsAuth, ":", 2)
 		if len(parts) == 2 {
@@ -431,13 +378,11 @@ func (app *App) startHttpServer(dnsClient *forwarder.RoundRobinClient, blocklist
 			}))
 			authorized.GET("/metrics", gin.WrapH(promhttp.Handler()))
 			authorized.GET("/reload", blocklistHandler.Reload)
-
 		} else {
 			return nil, errors.Newf("invalid metrics-auth value: %s", app.MetricsAuth)
 		}
 	}
 	r.POST("/check", blocklistHandler.Check)
-
 	if len(app.AllowedHosts) == 0 {
 		return nil, errors.New("cannot create mobileconfig handler: at least one hostname must be configured via --allowed-hosts")
 	}
@@ -445,26 +390,21 @@ func (app *App) startHttpServer(dnsClient *forwarder.RoundRobinClient, blocklist
 	r.GET("/.mobileconfig", routes.NewMobileconfigHandler(serverName))
 	r.GET("/", routes.RootHandler)
 	r.GET("/robots.txt", routes.RobotsTxtHandler)
-
 	return r, nil
 }
-
 func (app *App) environment() string {
 	if app.DevMode {
 		return "DEVELOPMENT"
 	}
 	return "PRODUCTION"
 }
-
 func newStructuredLoggingConfig() *sloggin.Config {
 	config := sloggin.DefaultConfig()
 	config.WithUserAgent = true
 	config.WithClientIP = true
 	config.Filters = append(config.Filters, sloggin.IgnorePath("/healthz", "/metrics"))
-
 	return &config
 }
-
 func (app *App) initIp2Location(crontab *cron.Cron) (geoblock.GeoIpLookup, error) {
 	geolocationDb := fmt.Sprintf("%s/ip2location/IP2LOCATION-LITE-DB1.BIN", app.DataDir)
 	if _, err := os.Stat(geolocationDb); os.IsNotExist(err) {
@@ -474,17 +414,14 @@ func (app *App) initIp2Location(crontab *cron.Cron) (geoblock.GeoIpLookup, error
 			return nil, errors.Wrap(err, "failed to download geoblock database")
 		}
 	}
-
 	app.Logger.Info("Loading geolocation database", "file", geolocationDb)
 	geoIpLookup, err := geoblock.NewGeoIpLookup(geolocationDb)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to open geoblock database")
 	}
-
 	app.Logger.Info("Creating IP2Location updater cron job", "schedule", app.CronSchedule.IP2Location)
 	if _, err = crontab.AddJob(app.CronSchedule.IP2Location, geoblock.NewIp2LocationUpdaterCronJob(app.Logger, "DB1LITEBIN", app.DataDir, geoIpLookup)); err != nil {
 		return nil, errors.Wrap(err, "failed to create IP2Location updater cron job")
 	}
-
 	return geoIpLookup, nil
 }

--- a/internal/forwarder/dispatcher.go
+++ b/internal/forwarder/dispatcher.go
@@ -293,6 +293,13 @@ func (d *DNSDispatcher) resolveUpstream(requestCtx *RequestContext, unansweredQu
 	upstreamReq.RecursionDesired = req.RecursionDesired
 	upstreamReq.Question = unansweredQuestions
 
+	for _, rr := range req.Extra {
+		if opt, ok := rr.(*dns.OPT); ok {
+			upstreamReq.Extra = append(upstreamReq.Extra, dns.Copy(opt))
+			break
+		}
+	}
+
 	upstreamResp, upstream, err := d.forwardQuery(requestCtx, upstreamReq)
 	if err != nil {
 		span.RecordError(err)

--- a/internal/forwarder/dispatcher_test.go
+++ b/internal/forwarder/dispatcher_test.go
@@ -91,7 +91,7 @@ func setupDispatcherTest(t *testing.T, upstream string, logger *slog.Logger) (*D
 	metrics, err := metrics.NewDNSMetrics(cache, mockGeo)
 	require.NoError(t, err)
 
-	dnsClient, err := NewRoundRobinClient(metrics, 2*time.Second, 2*time.Second, 2*time.Second, 1, logger, upstream)
+	dnsClient, err := NewRoundRobinClient(metrics, 2*time.Second, 2*time.Second, 2*time.Second, logger, upstream)
 	require.NoError(t, err)
 
 	dispatcher, err := NewDNSDispatcher(cache, metrics, dnsClient, blockList, 1*time.Minute, logger)
@@ -338,7 +338,7 @@ func TestDNSDispatcher_NegativeCacheTtlFloor(t *testing.T) {
 	metrics, err := metrics.NewDNSMetrics(cache, mockGeo)
 	assert.NoError(t, err)
 
-	dnsClient, err := NewRoundRobinClient(metrics, 2*time.Second, 2*time.Second, 2*time.Second, 1, logger, "8.8.8.8:53")
+	dnsClient, err := NewRoundRobinClient(metrics, 2*time.Second, 2*time.Second, 2*time.Second, logger, "8.8.8.8:53")
 	assert.NoError(t, err)
 
 	dispatcher, err := NewDNSDispatcher(cache, metrics, dnsClient, blockList, -1*time.Second, logger)
@@ -511,35 +511,20 @@ func startLocalDNS(t *testing.T, handler dns.HandlerFunc) (*dns.Server, string) 
 	t.Helper()
 	probeName := fmt.Sprintf("%s.dns-probe.local.", uuid.New().String())
 
-	l, err := net.Listen("tcp", "127.0.0.1:0")
-	require.NoError(t, err)
-	addr := l.Addr().String()
+	l, err := net.ListenPacket("udp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("failed to listen: %v", err)
+	}
+	addr := l.LocalAddr().String()
 
 	server := &dns.Server{
-		Listener: l,
-		Net:      "tcp",
-		Handler:  probeDecorator(probeName, handler),
-	}
-
-	started := make(chan struct{})
-	server.NotifyStartedFunc = func() {
-		close(started)
+		PacketConn: l,
+		Handler:    probeDecorator(probeName, handler),
 	}
 
 	go func() {
-		err := server.ActivateAndServe()
-		if err != nil {
-			// If it's already closed, don't fail the test
-			return
-		}
+		_ = server.ActivateAndServe()
 	}()
-
-	select {
-	case <-started:
-		t.Logf("Mock DNS server listening on: %s", addr)
-	case <-time.After(5 * time.Second):
-		t.Fatal("Timed out waiting for mock DNS server to become ready")
-	}
 
 	waitForPort(t, addr, probeName, 5*time.Second)
 	return server, addr
@@ -548,7 +533,7 @@ func startLocalDNS(t *testing.T, handler dns.HandlerFunc) (*dns.Server, string) 
 func waitForPort(t *testing.T, addr, probeName string, timeout time.Duration) {
 	t.Helper()
 	deadline := deadline(t, timeout)
-	client := dns.Client{DialTimeout: 100 * time.Millisecond, Net: "tcp"}
+	client := dns.Client{DialTimeout: 100 * time.Millisecond, Net: "udp"}
 	req := new(dns.Msg)
 	req.SetQuestion(probeName, dns.TypeA)
 

--- a/internal/forwarder/round_robin_client.go
+++ b/internal/forwarder/round_robin_client.go
@@ -15,87 +15,12 @@ import (
 )
 
 type RoundRobinClient struct {
-	upstreams []string
-	pools     map[string]*ConnPool
-	counter   uint32
-	logger    *slog.Logger
-	metrics   *metrics.DnsMetrics
-}
-
-type pooledConn struct {
-	conn       *dns.Conn
-	returnedAt time.Time
-}
-
-type ConnPool struct {
-	conns      chan *pooledConn
-	addr       string
-	client     *dns.Client
-	metrics    *metrics.DnsMetrics
-	maxIdleAge time.Duration
-}
-
-func NewConnPool(metrics *metrics.DnsMetrics, addr string, client *dns.Client, poolSize int) *ConnPool {
-	return &ConnPool{
-		conns:      make(chan *pooledConn, poolSize),
-		addr:       addr,
-		client:     client,
-		metrics:    metrics,
-		maxIdleAge: 8 * time.Second, // Close connections idle for more than 8 seconds
-	}
-}
-
-func (p *ConnPool) dial() (*dns.Conn, error) {
-	conn, err := p.client.Dial(p.addr)
-	if err != nil {
-		return nil, errors.Wrapf(err, "failed to dial %s", p.addr)
-	}
-	return conn, nil
-}
-
-func (p *ConnPool) acquire() (*dns.Conn, bool, error) {
-	for {
-		select {
-		case pc := <-p.conns:
-			if time.Since(pc.returnedAt) > p.maxIdleAge {
-				_ = pc.conn.Close() // stale, discard and try next
-				continue
-			}
-			return pc.conn, true, nil
-		default:
-			conn, err := p.dial()
-			return conn, false, err
-		}
-	}
-}
-
-func (p *ConnPool) release(conn *dns.Conn) {
-	select {
-	case p.conns <- &pooledConn{conn: conn, returnedAt: time.Now()}:
-	default:
-		_ = conn.Close() // pool full, discard
-		p.metrics.PoolEvictions.WithLabelValues(p.addr).Inc()
-	}
-}
-
-func (p *ConnPool) Exchange(msg *dns.Msg) (*dns.Msg, time.Duration, error) {
-	conn, reused, err := p.acquire()
-	if err != nil {
-		return nil, 0, err
-	}
-
-	resp, rtt, err := p.client.ExchangeWithConn(msg, conn)
-	if err != nil {
-		_ = conn.Close() // discard broken conn
-		if reused {
-			// Dont retry on a failed pooled connection, just move onto the next, but do record the failure
-			p.metrics.PooledConnDeaths.WithLabelValues(p.addr).Inc()
-		}
-		return nil, 0, err
-	}
-
-	p.release(conn)
-	return resp, rtt, nil
+	upstreams         []string          // Original configuration strings
+	resolvedUpstreams map[string]string // Mapping from config string to resolved IP:port
+	counter           uint32
+	logger            *slog.Logger
+	metrics           *metrics.DnsMetrics
+	client            *dns.Client
 }
 
 func resolveUpstream(logger *slog.Logger, upstream string) (string, error) {
@@ -104,12 +29,12 @@ func resolveUpstream(logger *slog.Logger, upstream string) (string, error) {
 		addr = net.JoinHostPort(addr, "53")
 	}
 
-	tcpAddr, err := net.ResolveTCPAddr("tcp", addr)
+	udpAddr, err := net.ResolveUDPAddr("udp", addr)
 	if err != nil {
 		return "", errors.Wrapf(err, "failed to resolve upstream %s", addr)
 	}
 
-	resolvedAddr := tcpAddr.String()
+	resolvedAddr := udpAddr.String()
 	if resolvedAddr != addr {
 		logger.Info("Resolved upstream", "fqdn", upstream, "ip_addr", resolvedAddr)
 	}
@@ -117,35 +42,33 @@ func resolveUpstream(logger *slog.Logger, upstream string) (string, error) {
 	return resolvedAddr, nil
 }
 
-func NewRoundRobinClient(metrics *metrics.DnsMetrics, readTimeout, writeTimeout, dialTimeout time.Duration, poolSize int, logger *slog.Logger, upstreams ...string) (*RoundRobinClient, error) {
+func NewRoundRobinClient(metrics *metrics.DnsMetrics, readTimeout, writeTimeout, dialTimeout time.Duration, logger *slog.Logger, upstreams ...string) (*RoundRobinClient, error) {
 	if len(upstreams) == 0 {
 		return nil, errors.New("no upstream servers configured")
 	}
 
-	if poolSize < 0 {
-		return nil, errors.New("connection pool size cannot be negative")
-	}
-
 	client := &dns.Client{
-		Net:          "tcp",
+		Net:          "udp",
 		DialTimeout:  dialTimeout,
 		ReadTimeout:  readTimeout,
 		WriteTimeout: writeTimeout,
 	}
-	pools := make(map[string]*ConnPool, len(upstreams))
+
+	resolved := make(map[string]string, len(upstreams))
 	for _, upstream := range upstreams {
-		resolvedAddr, err := resolveUpstream(logger, upstream)
+		addr, err := resolveUpstream(logger, upstream)
 		if err != nil {
 			return nil, err
 		}
-		pools[upstream] = NewConnPool(metrics, resolvedAddr, client, poolSize)
+		resolved[upstream] = addr
 	}
 
 	return &RoundRobinClient{
-		upstreams: upstreams,
-		pools:     pools,
-		logger:    logger,
-		metrics:   metrics,
+		upstreams:         upstreams,
+		resolvedUpstreams: resolved,
+		logger:            logger,
+		metrics:           metrics,
+		client:            client,
 	}, nil
 }
 
@@ -156,7 +79,9 @@ func (r *RoundRobinClient) Exchange(msg *dns.Msg) (*dns.Msg, string, error) {
 	var lastErr error
 	for i := range n {
 		upstream := r.upstreams[(start+i)%n]
-		resp, _, err := r.pools[upstream].Exchange(msg)
+		addr := r.resolvedUpstreams[upstream]
+
+		resp, _, err := r.client.Exchange(msg, addr)
 		if err == nil {
 			return resp, upstream, nil
 		}
@@ -197,29 +122,30 @@ func getFailureReason(err error) string {
 func (r *RoundRobinClient) Healthchecks() []checks.Check {
 	dnsChecks := make([]checks.Check, 0, len(r.upstreams))
 	for _, upstream := range r.upstreams {
-		check := &DNSCheck{
-			upstream: upstream,
-			pool:     r.pools[upstream],
-		}
-		dnsChecks = append(dnsChecks, check)
+		dnsChecks = append(dnsChecks, &DNSCheck{
+			client: r.client,
+			addr:   r.resolvedUpstreams[upstream],
+			name:   upstream,
+		})
 	}
 
 	return dnsChecks
 }
 
 type DNSCheck struct {
-	upstream string
-	pool     *ConnPool
+	client *dns.Client
+	addr   string
+	name   string
 }
 
 func (d *DNSCheck) Name() string {
-	return "DNS server " + d.upstream
+	return "DNS server " + d.name
 }
 
 func (d *DNSCheck) Pass() bool {
 	msg := new(dns.Msg)
 	msg.SetQuestion("google.com.", dns.TypeA)
 
-	_, _, err := d.pool.Exchange(msg)
+	_, _, err := d.client.Exchange(msg, d.addr)
 	return err == nil
 }

--- a/internal/forwarder/round_robin_client.go
+++ b/internal/forwarder/round_robin_client.go
@@ -14,13 +14,17 @@ import (
 	"github.com/tavsec/gin-healthcheck/checks"
 )
 
+type upstreamServer struct {
+	config string
+	addr   string
+}
+
 type RoundRobinClient struct {
-	upstreams         []string          // Original configuration strings
-	resolvedUpstreams map[string]string // Mapping from config string to resolved IP:port
-	counter           uint32
-	logger            *slog.Logger
-	metrics           *metrics.DnsMetrics
-	client            *dns.Client
+	upstreams []upstreamServer
+	counter   uint32
+	logger    *slog.Logger
+	metrics   *metrics.DnsMetrics
+	client    *dns.Client
 }
 
 func resolveUpstream(logger *slog.Logger, upstream string) (string, error) {
@@ -54,21 +58,20 @@ func NewRoundRobinClient(metrics *metrics.DnsMetrics, readTimeout, writeTimeout,
 		WriteTimeout: writeTimeout,
 	}
 
-	resolved := make(map[string]string, len(upstreams))
-	for _, upstream := range upstreams {
-		addr, err := resolveUpstream(logger, upstream)
+	resolved := make([]upstreamServer, 0, len(upstreams))
+	for _, config := range upstreams {
+		addr, err := resolveUpstream(logger, config)
 		if err != nil {
 			return nil, err
 		}
-		resolved[upstream] = addr
+		resolved = append(resolved, upstreamServer{config: config, addr: addr})
 	}
 
 	return &RoundRobinClient{
-		upstreams:         upstreams,
-		resolvedUpstreams: resolved,
-		logger:            logger,
-		metrics:           metrics,
-		client:            client,
+		upstreams: resolved,
+		logger:    logger,
+		metrics:   metrics,
+		client:    client,
 	}, nil
 }
 
@@ -78,19 +81,18 @@ func (r *RoundRobinClient) Exchange(msg *dns.Msg) (*dns.Msg, string, error) {
 
 	var lastErr error
 	for i := range n {
-		upstream := r.upstreams[(start+i)%n]
-		addr := r.resolvedUpstreams[upstream]
+		server := r.upstreams[(start+i)%n]
 
-		resp, _, err := r.client.Exchange(msg, addr)
+		resp, _, err := r.client.Exchange(msg, server.addr)
 		if err == nil {
-			return resp, upstream, nil
+			return resp, server.config, nil
 		}
 
 		reason := getFailureReason(err)
-		r.metrics.UpstreamFailures.WithLabelValues(upstream, reason).Inc()
-		r.logger.Warn("upstream failure", "upstream", upstream, "reason", reason, "error", err)
+		r.metrics.UpstreamFailures.WithLabelValues(server.config, reason).Inc()
+		r.logger.Warn("upstream failure", "upstream", server.config, "reason", reason, "error", err)
 
-		lastErr = errors.Wrapf(err, "upstream %s failed", upstream)
+		lastErr = errors.Wrapf(err, "upstream %s failed", server.config)
 	}
 	return nil, "", errors.Wrap(lastErr, "all upstream servers failed")
 }
@@ -121,11 +123,11 @@ func getFailureReason(err error) string {
 
 func (r *RoundRobinClient) Healthchecks() []checks.Check {
 	dnsChecks := make([]checks.Check, 0, len(r.upstreams))
-	for _, upstream := range r.upstreams {
+	for _, server := range r.upstreams {
 		dnsChecks = append(dnsChecks, &DNSCheck{
 			client: r.client,
-			addr:   r.resolvedUpstreams[upstream],
-			name:   upstream,
+			addr:   server.addr,
+			name:   server.config,
 		})
 	}
 

--- a/main.go
+++ b/main.go
@@ -108,7 +108,6 @@ func main() {
 	rootCmd.Flags().DurationVar(&app.Timeouts.Read, "read-timeout", 300*time.Millisecond, "Timeout for reading upstream DNS queries")
 	rootCmd.Flags().DurationVar(&app.Timeouts.Write, "write-timeout", 100*time.Millisecond, "Timeout for writing upstream DNS queries")
 	rootCmd.Flags().DurationVar(&app.Timeouts.Dial, "dial-timeout", 300*time.Millisecond, "Timeout for establishing connections to upstream servers")
-	rootCmd.Flags().IntVar(&app.ConnectionPoolSize, "connection-pool-size", 10, "Number of connections to maintain in pool for each upstream server")
 	rootCmd.Flags().BoolVar(&app.RequireProxyProtocol, "require-proxy-protocol", false, "Require PROXY protocol header for DoT connections")
 	rootCmd.Flags().StringSliceVar(&app.TrustedProxies, "trusted-proxies", nil, "Comma-separated list of trusted proxy IP addresses or CIDR ranges")
 


### PR DESCRIPTION
- Replace connection pooling with direct UDP exchange to simplify the
  forwarder implementation.
- Update DNS dispatcher to pass EDNS0 options from incoming requests
  to upstream servers.
- Simplify `RoundRobinClient` by removing the connection pool
  sub-system.