### PR TITLE
feat: add EDNS0 Client Subnet (ECS) support

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,6 +200,7 @@ DoT Block can be configured using the following command-line flags:
 | `--metrics-auth` | Credentials for basic auth on `/metrics` (format: `user:pass`). | `""` |
 | `--require-proxy-protocol` | Require PROXY protocol header for DoT connections. | `false` |
 | `--trusted-proxies` | Comma-separated list of trusted proxy IP addresses or CIDR ranges. | `nil` |
+| `--enable-ecs` | Enable EDNS0 Client Subnet (ECS) steering. This allows the server to send the client's network prefix to upstream resolvers for location-aware responses. | `false` |
 | `--upstreams` | Upstream DNS resolvers to forward queries to. (Port 53 is assumed if omitted) | `8.8.8.8`, `8.8.4.4`, `1.1.1.1`, `1.0.0.1`, `9.9.9.9`, `149.112.112.112` |
 
 ### Environment Variables

--- a/internal/app.go
+++ b/internal/app.go
@@ -62,6 +62,7 @@ type App struct {
 	CacheTtlFloor        time.Duration `json:"cache_ttl_floor"`
 	RequireProxyProtocol bool          `json:"require_proxy_protocol"`
 	TrustedProxies       []string      `json:"trusted_proxies,omitempty"`
+	EnableECS            bool          `json:"enable_ecs"`
 	Timeouts             struct {
 		Read  time.Duration `json:"read"`
 		Write time.Duration `json:"write"`
@@ -208,7 +209,7 @@ func (app *App) RunServer(ctx context.Context) error {
 		return errors.Wrap(err, "failed to initialize upstream DNS client")
 	}
 
-	dispatcher, err := forwarder.NewDNSDispatcher(cache, metrics, dnsClient, blockList, app.CacheTtlFloor, app.Logger)
+	dispatcher, err := forwarder.NewDNSDispatcher(cache, metrics, dnsClient, blockList, app.CacheTtlFloor, app.Logger, app.EnableECS)
 	if err != nil {
 		return errors.Wrap(err, "failed to create dispatcher")
 	}

--- a/internal/forwarder/dispatcher.go
+++ b/internal/forwarder/dispatcher.go
@@ -40,6 +40,8 @@ type RequestContext struct {
 	ctx      context.Context
 	snapshot *metrics.RequestSnapshot
 	logger   *slog.Logger
+	ipAddr   string
+	subnet   string
 }
 
 type DispatcherFunc func(writer dns.ResponseWriter, req *dns.Msg)
@@ -52,6 +54,7 @@ type DNSDispatcher struct {
 	blockList  *blocklist.BlockList
 	metrics    *metrics.DnsMetrics
 	logger     *slog.Logger
+	enableECS  bool
 	snapshotCh chan *metrics.RequestSnapshot
 	done       chan struct{}
 }
@@ -63,6 +66,7 @@ func NewDNSDispatcher(
 	blockList *blocklist.BlockList,
 	ttlFloor time.Duration,
 	logger *slog.Logger,
+	enableECS bool,
 ) (*DNSDispatcher, error) {
 
 	if ttlFloor < 0 {
@@ -77,6 +81,7 @@ func NewDNSDispatcher(
 		blockList:  blockList,
 		metrics:    dnsMetrics,
 		logger:     logger,
+		enableECS:  enableECS,
 		snapshotCh: make(chan *metrics.RequestSnapshot, SNAPSHOT_BUFFER_SIZE),
 		done:       make(chan struct{}),
 	}
@@ -85,7 +90,7 @@ func NewDNSDispatcher(
 		go d.snapshotWorker()
 	}
 
-	logger.Info("DNS dispatcher initialized", "num_snapshot_workers", NUM_WORKERS)
+	logger.Info("DNS dispatcher initialized", "num_snapshot_workers", NUM_WORKERS, "enable_ecs", enableECS)
 	return d, nil
 }
 
@@ -128,6 +133,8 @@ func (d *DNSDispatcher) HandleDNSRequest(source DNSSource) DispatcherFunc {
 			ctx:      ctx,
 			logger:   d.logger.With("client_ip", ipAddr, "request_id", req.Id, "source", source),
 			snapshot: metrics.NewRequestSnapshot(time.Now(), string(source), ipAddr),
+			ipAddr:   ipAddr,
+			subnet:   d.computeSubnet(ipAddr),
 		}
 
 		defer func() {
@@ -272,7 +279,7 @@ func (d *DNSDispatcher) processQuestion(requestCtx *RequestContext, q *dns.Quest
 
 	requestCtx.snapshot.AddDomain(q.Name)
 	requestCtx.snapshot.AddQueryCount(queryType, false)
-	if cachedRRs, ok := d.cache.Get(getCacheKey(q)); ok {
+	if cachedRRs, ok := d.cache.Get(getCacheKey(q, requestCtx.subnet)); ok {
 		span.SetAttributes(attribute.Bool("dns.cache_hit", true))
 		return cachedRRs, dns.RcodeSuccess, nil
 	}
@@ -301,6 +308,8 @@ func (d *DNSDispatcher) resolveUpstream(requestCtx *RequestContext, unansweredQu
 		}
 	}
 
+	d.applyECS(requestCtx, upstreamReq)
+
 	upstreamResp, upstream, err := d.forwardQuery(requestCtx, upstreamReq)
 	if err != nil {
 		span.RecordError(err)
@@ -327,7 +336,7 @@ func (d *DNSDispatcher) resolveUpstream(requestCtx *RequestContext, unansweredQu
 
 	// Process unanswered questions and cache the results
 	for _, q := range unansweredQuestions {
-		key := getCacheKey(&q)
+		key := getCacheKey(&q, requestCtx.subnet)
 		if answersForQuestion, ok := answerMap[key]; ok {
 			upstreamTTL := answersForQuestion[0].Header().Ttl
 			effectiveTTL := time.Duration(upstreamTTL) * time.Second
@@ -342,6 +351,76 @@ func (d *DNSDispatcher) resolveUpstream(requestCtx *RequestContext, unansweredQu
 	}
 
 	return upstreamReq.Rcode, upstreamResp.Answer, nil
+}
+
+func (d *DNSDispatcher) computeSubnet(ipAddr string) string {
+	if !d.enableECS || ipAddr == "unknown" {
+		return ""
+	}
+
+	ip := net.ParseIP(ipAddr)
+	if ip == nil {
+		return ""
+	}
+
+	if ip4 := ip.To4(); ip4 != nil {
+		mask := net.CIDRMask(24, 32)
+		return string(ip4.Mask(mask))
+	}
+
+	mask := net.CIDRMask(48, 128)
+	return string(ip.Mask(mask))
+}
+
+func (d *DNSDispatcher) applyECS(requestCtx *RequestContext, upstreamReq *dns.Msg) {
+	if !d.enableECS || requestCtx.ipAddr == "unknown" {
+		return
+	}
+
+	ip := net.ParseIP(requestCtx.ipAddr)
+	if ip == nil {
+		return
+	}
+
+	var family uint16
+	var prefixLen uint8
+	if ip4 := ip.To4(); ip4 != nil {
+		family = 1
+		prefixLen = 24
+		ip = ip4
+	} else {
+		family = 2
+		prefixLen = 48
+	}
+
+	ecs := &dns.EDNS0_SUBNET{
+		Code:          dns.EDNS0SUBNET,
+		Family:        family,
+		SourceNetmask: prefixLen,
+		SourceScope:   0,
+		Address:       ip,
+	}
+
+	found := false
+	for _, rr := range upstreamReq.Extra {
+		if opt, ok := rr.(*dns.OPT); ok {
+			opt.Option = append(opt.Option, ecs)
+			found = true
+			break
+		}
+	}
+	if !found {
+		opt := &dns.OPT{
+			Hdr: dns.RR_Header{
+				Name:   ".",
+				Rrtype: dns.TypeOPT,
+				Class:  dns.ClassINET,
+				Ttl:    4096,
+			},
+			Option: []dns.EDNS0{ecs},
+		}
+		upstreamReq.Extra = append(upstreamReq.Extra, opt)
+	}
 }
 
 func (d *DNSDispatcher) isFreshnessSensitive(q *dns.Question) bool {
@@ -403,8 +482,12 @@ func (d *DNSDispatcher) sendResponse(ctx *RequestContext, writer dns.ResponseWri
 	}
 }
 
-func getCacheKey(q *dns.Question) string {
-	return dns.Fqdn(q.Name) + ":" + getQueryType(q)
+func getCacheKey(q *dns.Question, subnet string) string {
+	key := dns.Fqdn(q.Name) + ":" + getQueryType(q)
+	if subnet != "" {
+		key += ":" + subnet
+	}
+	return key
 }
 
 func getQueryType(q *dns.Question) string {

--- a/internal/forwarder/dispatcher.go
+++ b/internal/forwarder/dispatcher.go
@@ -405,8 +405,20 @@ func (d *DNSDispatcher) applyECS(requestCtx *RequestContext, upstreamReq *dns.Ms
 	found := false
 	for _, rr := range upstreamReq.Extra {
 		if opt, ok := rr.(*dns.OPT); ok {
-			opt.Option = append(opt.Option, ecs)
 			found = true
+			ecsIndex := -1
+			for i, o := range opt.Option {
+				if _, ok := o.(*dns.EDNS0_SUBNET); ok {
+					ecsIndex = i
+					break
+				}
+			}
+
+			if ecsIndex != -1 {
+				opt.Option[ecsIndex] = ecs
+			} else {
+				opt.Option = append(opt.Option, ecs)
+			}
 			break
 		}
 	}

--- a/internal/forwarder/dispatcher.go
+++ b/internal/forwarder/dispatcher.go
@@ -408,7 +408,7 @@ func (d *DNSDispatcher) applyECS(requestCtx *RequestContext, upstreamReq *dns.Ms
 			found = true
 			ecsIndex := -1
 			for i, o := range opt.Option {
-				if _, ok := o.(*dns.EDNS0_SUBNET); ok {
+				if o.Option() == dns.EDNS0SUBNET {
 					ecsIndex = i
 					break
 				}

--- a/internal/forwarder/dispatcher.go
+++ b/internal/forwarder/dispatcher.go
@@ -365,11 +365,11 @@ func (d *DNSDispatcher) computeSubnet(ipAddr string) string {
 
 	if ip4 := ip.To4(); ip4 != nil {
 		mask := net.CIDRMask(24, 32)
-		return string(ip4.Mask(mask))
+		return ip4.Mask(mask).String()
 	}
 
 	mask := net.CIDRMask(48, 128)
-	return string(ip.Mask(mask))
+	return ip.Mask(mask).String()
 }
 
 func (d *DNSDispatcher) applyECS(requestCtx *RequestContext, upstreamReq *dns.Msg) {
@@ -387,10 +387,11 @@ func (d *DNSDispatcher) applyECS(requestCtx *RequestContext, upstreamReq *dns.Ms
 	if ip4 := ip.To4(); ip4 != nil {
 		family = 1
 		prefixLen = 24
-		ip = ip4
+		ip = ip4.Mask(net.CIDRMask(24, 32))
 	} else {
 		family = 2
 		prefixLen = 48
+		ip = ip.Mask(net.CIDRMask(48, 128))
 	}
 
 	ecs := &dns.EDNS0_SUBNET{

--- a/internal/forwarder/dispatcher_test.go
+++ b/internal/forwarder/dispatcher_test.go
@@ -384,7 +384,8 @@ func TestDNSDispatcher_HandleDNSRequest_UpstreamNXDOMAIN_NoLogError(t *testing.T
 		_ = w.WriteMsg(m)
 	})
 	defer func() {
-		_ = server.Shutdown()
+		err := server.Shutdown()
+		assert.NoError(t, err)
 	}()
 
 	dispatcher, _, _, _ := setupDispatcherTest(t, upstream, logger, false)
@@ -416,7 +417,8 @@ func TestDNSDispatcher_HandleDNSRequest_UpstreamNOTIMP_NoLogError(t *testing.T) 
 		_ = w.WriteMsg(m)
 	})
 	defer func() {
-		_ = server.Shutdown()
+		err := server.Shutdown()
+		assert.NoError(t, err)
 	}()
 
 	dispatcher, _, _, _ := setupDispatcherTest(t, upstream, logger, false)
@@ -448,7 +450,8 @@ func TestDNSDispatcher_HandleDNSRequest_UpstreamSERVFAIL_LogError(t *testing.T) 
 		_ = w.WriteMsg(m)
 	})
 	defer func() {
-		_ = server.Shutdown()
+		err := server.Shutdown()
+		assert.NoError(t, err)
 	}()
 
 	dispatcher, _, _, _ := setupDispatcherTest(t, upstream, logger, false)
@@ -650,7 +653,10 @@ func TestDNSDispatcher_ECS_Injection(t *testing.T) {
 				_ = w.WriteMsg(m)
 				close(done)
 			})
-			defer server.Shutdown()
+			defer func() {
+				err := server.Shutdown()
+				assert.NoError(t, err)
+			}()
 
 			// Setup dispatcher with the specific enableECS setting
 			logger := slog.New(slog.NewTextHandler(io.Discard, nil))

--- a/internal/forwarder/dispatcher_test.go
+++ b/internal/forwarder/dispatcher_test.go
@@ -77,7 +77,7 @@ func (m *MockResponseWriter) TsigTimersOnly(b bool) {
 func (m *MockResponseWriter) Hijack() {
 }
 
-func setupDispatcherTest(t *testing.T, upstream string, logger *slog.Logger) (*DNSDispatcher, *MockGeoIpLookup, *blocklist.BlockList, *slog.Logger) {
+func setupDispatcherTest(t *testing.T, upstream string, logger *slog.Logger, enableECS bool) (*DNSDispatcher, *MockGeoIpLookup, *blocklist.BlockList, *slog.Logger) {
 	t.Helper()
 	if logger == nil {
 		logger = slog.New(slog.NewTextHandler(io.Discard, nil))
@@ -94,7 +94,7 @@ func setupDispatcherTest(t *testing.T, upstream string, logger *slog.Logger) (*D
 	dnsClient, err := NewRoundRobinClient(metrics, 2*time.Second, 2*time.Second, 2*time.Second, logger, upstream)
 	require.NoError(t, err)
 
-	dispatcher, err := NewDNSDispatcher(cache, metrics, dnsClient, blockList, 1*time.Minute, logger)
+	dispatcher, err := NewDNSDispatcher(cache, metrics, dnsClient, blockList, 1*time.Minute, logger, enableECS)
 	require.NoError(t, err)
 	t.Cleanup(dispatcher.Close)
 
@@ -130,7 +130,7 @@ func TestDNSDispatcher_HandleDNSRequest_MixedBlockedAndUpstream(t *testing.T) {
 		assert.NoError(t, err)
 	}()
 
-	dispatcher, _, _, _ := setupDispatcherTest(t, upstream, nil)
+	dispatcher, _, _, _ := setupDispatcherTest(t, upstream, nil, false)
 
 	req := new(dns.Msg)
 	req.Question = []dns.Question{
@@ -170,7 +170,7 @@ func TestDNSDispatcher_HandleDNSRequest_Allowed(t *testing.T) {
 		assert.NoError(t, err)
 	}()
 
-	dispatcher, _, _, _ := setupDispatcherTest(t, upstream, nil)
+	dispatcher, _, _, _ := setupDispatcherTest(t, upstream, nil, false)
 
 	req := new(dns.Msg)
 	req.SetQuestion("google.com.", dns.TypeA)
@@ -197,7 +197,7 @@ func TestDNSDispatcher_HandleDNSRequest_Blocked(t *testing.T) {
 		assert.NoError(t, err)
 	}()
 
-	dispatcher, _, _, _ := setupDispatcherTest(t, upstream, nil)
+	dispatcher, _, _, _ := setupDispatcherTest(t, upstream, nil, false)
 
 	req := new(dns.Msg)
 	req.SetQuestion("ads.0xbt.net.", dns.TypeA)
@@ -227,7 +227,7 @@ func TestDNSDispatcher_HandleDNSRequest_MultipleQuestions(t *testing.T) {
 		assert.NoError(t, err)
 	}()
 
-	dispatcher, _, _, _ := setupDispatcherTest(t, upstream, nil)
+	dispatcher, _, _, _ := setupDispatcherTest(t, upstream, nil, false)
 
 	req := new(dns.Msg)
 	req.Question = []dns.Question{
@@ -269,7 +269,7 @@ func TestDNSDispatcher_HandleDNSRequest_CacheHit(t *testing.T) {
 		assert.NoError(t, err)
 	}()
 
-	dispatcher, _, _, _ := setupDispatcherTest(t, upstream, nil)
+	dispatcher, _, _, _ := setupDispatcherTest(t, upstream, nil, false)
 
 	req := new(dns.Msg)
 	req.SetQuestion("example.com.", dns.TypeA)
@@ -287,7 +287,7 @@ func TestDNSDispatcher_HandleDNSRequest_CacheHit(t *testing.T) {
 	writer.On("WriteMsg", mock.Anything).Return(nil)
 
 	// Ensure the cache item is actually retrievable
-	cacheKey := getCacheKey(&req.Question[0])
+	cacheKey := getCacheKey(&req.Question[0], "")
 	assert.Eventually(t, func() bool {
 		_, ok := dispatcher.cache.Get(cacheKey)
 		return ok // Wait until Get actually finds the item
@@ -312,7 +312,7 @@ func TestDNSDispatcher_ResolveUpstream_BadRCode(t *testing.T) {
 		assert.NoError(t, err)
 	}()
 
-	dispatcher, _, _, _ := setupDispatcherTest(t, upstream, nil)
+	dispatcher, _, _, _ := setupDispatcherTest(t, upstream, nil, false)
 
 	req := new(dns.Msg)
 	req.SetQuestion("google.com.", dns.TypeA)
@@ -341,7 +341,7 @@ func TestDNSDispatcher_NegativeCacheTtlFloor(t *testing.T) {
 	dnsClient, err := NewRoundRobinClient(metrics, 2*time.Second, 2*time.Second, 2*time.Second, logger, "8.8.8.8:53")
 	assert.NoError(t, err)
 
-	dispatcher, err := NewDNSDispatcher(cache, metrics, dnsClient, blockList, -1*time.Second, logger)
+	dispatcher, err := NewDNSDispatcher(cache, metrics, dnsClient, blockList, -1*time.Second, logger, false)
 	assert.Error(t, err)
 	assert.Nil(t, dispatcher)
 	assert.Contains(t, err.Error(), "TTL floor cannot be negative")
@@ -358,7 +358,7 @@ func TestDNSDispatcher_HandleDNSRequest_DNSSD_NXDOMAIN(t *testing.T) {
 		assert.NoError(t, err)
 	}()
 
-	dispatcher, _, _, _ := setupDispatcherTest(t, upstream, nil)
+	dispatcher, _, _, _ := setupDispatcherTest(t, upstream, nil, false)
 
 	req := new(dns.Msg)
 	req.SetQuestion("db._dns-sd._udp.0.68.168.192.in-addr.arpa.", dns.TypePTR)
@@ -387,7 +387,7 @@ func TestDNSDispatcher_HandleDNSRequest_UpstreamNXDOMAIN_NoLogError(t *testing.T
 		_ = server.Shutdown()
 	}()
 
-	dispatcher, _, _, _ := setupDispatcherTest(t, upstream, logger)
+	dispatcher, _, _, _ := setupDispatcherTest(t, upstream, logger, false)
 
 	req := new(dns.Msg)
 	req.SetQuestion("nonexistent.example.com.", dns.TypeA)
@@ -419,7 +419,7 @@ func TestDNSDispatcher_HandleDNSRequest_UpstreamNOTIMP_NoLogError(t *testing.T) 
 		_ = server.Shutdown()
 	}()
 
-	dispatcher, _, _, _ := setupDispatcherTest(t, upstream, logger)
+	dispatcher, _, _, _ := setupDispatcherTest(t, upstream, logger, false)
 
 	req := new(dns.Msg)
 	req.SetQuestion("notimp.example.com.", dns.TypeA)
@@ -451,7 +451,7 @@ func TestDNSDispatcher_HandleDNSRequest_UpstreamSERVFAIL_LogError(t *testing.T) 
 		_ = server.Shutdown()
 	}()
 
-	dispatcher, _, _, _ := setupDispatcherTest(t, upstream, logger)
+	dispatcher, _, _, _ := setupDispatcherTest(t, upstream, logger, false)
 
 	req := new(dns.Msg)
 	req.SetQuestion("error.example.com.", dns.TypeA)
@@ -559,7 +559,7 @@ func deadline(t *testing.T, timeout time.Duration) time.Time {
 }
 
 func TestDNSDispatcher_ReservedTLDs(t *testing.T) {
-	dispatcher, _, _, _ := setupDispatcherTest(t, "127.0.0.1:53", nil)
+	dispatcher, _, _, _ := setupDispatcherTest(t, "127.0.0.1:53", nil, false)
 
 	tests := []struct {
 		name     string
@@ -597,4 +597,140 @@ func TestDNSDispatcher_ReservedTLDs(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestDNSDispatcher_ECS_Injection(t *testing.T) {
+	tests := []struct {
+		name       string
+		enableECS  bool
+		clientIP   string
+		expectECS  bool
+		expectFam  uint16
+		expectMask uint8
+	}{
+		{
+			name:       "IPv4 Enabled",
+			enableECS:  true,
+			clientIP:   "1.2.3.4",
+			expectECS:  true,
+			expectFam:  1,
+			expectMask: 24,
+		},
+		{
+			name:      "IPv4 Disabled",
+			enableECS: false,
+			clientIP:  "1.2.3.4",
+			expectECS: false,
+		},
+		{
+			name:       "IPv6 Enabled",
+			enableECS:  true,
+			clientIP:   "2001:db8::1",
+			expectECS:  true,
+			expectFam:  2,
+			expectMask: 48,
+		},
+		{
+			name:      "Unknown IP",
+			enableECS: true,
+			clientIP:  "unknown",
+			expectECS: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var capturedReq *dns.Msg
+			server, upstream := startLocalDNS(t, func(w dns.ResponseWriter, r *dns.Msg) {
+				capturedReq = r
+				m := new(dns.Msg)
+				m.SetReply(r)
+				m.SetRcode(r, dns.RcodeSuccess)
+				_ = w.WriteMsg(m)
+			})
+			defer server.Shutdown()
+
+			// Setup dispatcher with the specific enableECS setting
+			logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+			blockList := blocklist.NewBlockList([]string{}, 0.0001, logger)
+			cache := NewDNSCache(100, logger)
+			mockGeo := new(MockGeoIpLookup)
+			mockGeo.On("GetAll", mock.Anything).Return(ip2location.IP2Locationrecord{}, nil)
+			metrics, _ := metrics.NewDNSMetrics(cache, mockGeo)
+			dnsClient, _ := NewRoundRobinClient(metrics, 2*time.Second, 2*time.Second, 2*time.Second, logger, upstream)
+
+			dispatcher, _ := NewDNSDispatcher(cache, metrics, dnsClient, blockList, 1*time.Minute, logger, tt.enableECS)
+			defer dispatcher.Close()
+
+			// Mock ResponseWriter with the specific client IP
+			writer := &mockIPResponseWriter{
+				ip:   tt.clientIP,
+				port: 12345,
+				Mock: mock.Mock{},
+			}
+			writer.On("WriteMsg", mock.Anything).Return(nil)
+
+			req := new(dns.Msg)
+			req.SetQuestion("example.com.", dns.TypeA)
+
+			dispatcher.HandleDNSRequest("test")(writer, req)
+
+			require.NotNil(t, capturedReq)
+
+			foundECS := false
+			for _, rr := range capturedReq.Extra {
+				if opt, ok := rr.(*dns.OPT); ok {
+					for _, o := range opt.Option {
+						if ecs, ok := o.(*dns.EDNS0_SUBNET); ok {
+							foundECS = true
+							assert.Equal(t, tt.expectFam, ecs.Family)
+							assert.Equal(t, tt.expectMask, ecs.SourceNetmask)
+						}
+					}
+				}
+			}
+
+			assert.Equal(t, tt.expectECS, foundECS, "ECS option presence mismatch")
+		})
+	}
+}
+
+type mockIPResponseWriter struct {
+	ip   string
+	port int
+	mock.Mock
+}
+
+func (m *mockIPResponseWriter) LocalAddr() net.Addr {
+	return &net.TCPAddr{IP: net.ParseIP("127.0.0.1"), Port: 8080}
+}
+
+func (m *mockIPResponseWriter) RemoteAddr() net.Addr {
+	return &net.TCPAddr{IP: net.ParseIP(m.ip), Port: m.port}
+}
+
+func (m *mockIPResponseWriter) WriteMsg(msg *dns.Msg) error {
+	args := m.Called(msg)
+	return args.Error(0)
+}
+
+func (m *mockIPResponseWriter) Write(b []byte) (int, error) {
+	return len(b), nil
+}
+
+func (m *mockIPResponseWriter) Close() error {
+	return nil
+
+}
+
+func (m *mockIPResponseWriter) TsigStatus() error {
+	return nil
+}
+
+func (m *mockIPResponseWriter) TsigTimersOnly(b bool) {
+
+}
+
+func (m *mockIPResponseWriter) Hijack() {
+
 }

--- a/internal/forwarder/dispatcher_test.go
+++ b/internal/forwarder/dispatcher_test.go
@@ -641,12 +641,14 @@ func TestDNSDispatcher_ECS_Injection(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			var capturedReq *dns.Msg
+			done := make(chan struct{})
 			server, upstream := startLocalDNS(t, func(w dns.ResponseWriter, r *dns.Msg) {
-				capturedReq = r
+				capturedReq = r.Copy()
 				m := new(dns.Msg)
 				m.SetReply(r)
 				m.SetRcode(r, dns.RcodeSuccess)
 				_ = w.WriteMsg(m)
+				close(done)
 			})
 			defer server.Shutdown()
 
@@ -674,6 +676,12 @@ func TestDNSDispatcher_ECS_Injection(t *testing.T) {
 			req.SetQuestion("example.com.", dns.TypeA)
 
 			dispatcher.HandleDNSRequest("test")(writer, req)
+
+			select {
+			case <-done:
+			case <-time.After(2 * time.Second):
+				t.Fatal("timed out waiting for upstream server to receive request")
+			}
 
 			require.NotNil(t, capturedReq)
 

--- a/internal/integration_test.go
+++ b/internal/integration_test.go
@@ -151,7 +151,6 @@ func TestIntegration_DNSFunctionality(t *testing.T) {
 		},
 	}
 
-
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			var resp *dns.Msg

--- a/main.go
+++ b/main.go
@@ -110,6 +110,7 @@ func main() {
 	rootCmd.Flags().DurationVar(&app.Timeouts.Dial, "dial-timeout", 300*time.Millisecond, "Timeout for establishing connections to upstream servers")
 	rootCmd.Flags().BoolVar(&app.RequireProxyProtocol, "require-proxy-protocol", false, "Require PROXY protocol header for DoT connections")
 	rootCmd.Flags().StringSliceVar(&app.TrustedProxies, "trusted-proxies", nil, "Comma-separated list of trusted proxy IP addresses or CIDR ranges")
+	rootCmd.Flags().BoolVar(&app.EnableECS, "enable-ecs", false, "Enable EDNS0 Client Subnet (ECS) steering")
 
 	if err := rootCmd.Execute(); err != nil {
 		app.Logger.Error("Failed to execute command", "error", err)


### PR DESCRIPTION
- Added `--enable-ecs` flag to enable location-aware DNS responses.
- Implemented subnet calculation based on client IP (masking /24 for IPv4 and /48 for IPv6).
- Injected ECS option into upstream queries.
- Updated caching logic to include the subnet in the cache key.
- Added comprehensive unit tests for ECS injection and cache key isolation.

Fixes #50