### PR TITLE
feat: implement remote log noise filter

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,6 +184,7 @@ DoT Block can be configured using the following command-line flags:
 | :--- | :--- | :--- |
 | `--allowed-hosts` | List of domains used for the CertManager allow policy. | `nil` |
 | `--blocklist-url` | List of URL blocklists (wildcard hostname format). | `https://codeberg.org/hagezi/mirror2/raw/branch/main/dns-blocklists/hosts/pro.txt`, `https://raw.githubusercontent.com/rm-hull/dot-block/refs/heads/main/data/blocklist.txt` |
+| `--noise-filter-url` | List of URL noise filters (CSV format: category,rcode,domain_suffix). | `nil` |
 | `--cache-ttl-floor` | Minimum TTL for cached entries (in seconds). If a response is not "freshness sensitive" (e.g. contains `ocsp`, `crl`, `pki` or is `SOA`/`TXT`), the cache TTL will be at least this value. | `3600s` |
 | `--dial-timeout` | Timeout for establishing TCP connections to upstream servers | `300ms` |
 | `--read-timeout` | Timeout for waiting for responses from upstream DNS servers | `300ms` |

--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ dig @dot.your-domain.com -p <DNS_PORT> example.com A
 
 ```bash
 # DNS-over-TLS
-dig @dot.your-domain.com -p 853 +tls example.com    
+dig @dot.your-domain.com -p 853 +tls example.com
 
 # DNS-over-HTTPS
 dig @dot.your-domain.com -p 443 +https example.com A
@@ -184,7 +184,7 @@ DoT Block can be configured using the following command-line flags:
 | :--- | :--- | :--- |
 | `--allowed-hosts` | List of domains used for the CertManager allow policy. | `nil` |
 | `--blocklist-url` | List of URL blocklists (wildcard hostname format). | `https://codeberg.org/hagezi/mirror2/raw/branch/main/dns-blocklists/hosts/pro.txt`, `https://raw.githubusercontent.com/rm-hull/dot-block/refs/heads/main/data/blocklist.txt` |
-| `--noise-filter-url` | List of URL noise filters (CSV format: category,rcode,domain_suffix). | `nil` |
+| `--noise-filter-url` | URL of noise filter (CSV format: category,rcode,domain_suffix). | `https://raw.githubusercontent.com/rm-hull/dot-block/refs/heads/main/data/noise-filter.txt` |
 | `--cache-ttl-floor` | Minimum TTL for cached entries (in seconds). If a response is not "freshness sensitive" (e.g. contains `ocsp`, `crl`, `pki` or is `SOA`/`TXT`), the cache TTL will be at least this value. | `3600s` |
 | `--dial-timeout` | Timeout for establishing TCP connections to upstream servers | `300ms` |
 | `--read-timeout` | Timeout for waiting for responses from upstream DNS servers | `300ms` |

--- a/data/noise-filter.csv
+++ b/data/noise-filter.csv
@@ -1,0 +1,4 @@
+category,rcode,domain_suffix
+upstream,REFUSED,akadns.net
+upstream,REFUSED,akamaiedge.net
+upstream,REFUSED,akamai.net

--- a/internal/app.go
+++ b/internal/app.go
@@ -30,6 +30,7 @@ import (
 	"github.com/rm-hull/dot-block/internal/geoblock"
 	"github.com/rm-hull/dot-block/internal/logging"
 	"github.com/rm-hull/dot-block/internal/metrics"
+	"github.com/rm-hull/dot-block/internal/noisefilter"
 	"github.com/rm-hull/dot-block/internal/routes"
 	"github.com/rm-hull/dot-block/internal/telemetry"
 	"github.com/rm-hull/godx"
@@ -50,6 +51,7 @@ type App struct {
 	DotPort            int          `json:"dot_port"`
 	Upstreams          []string     `json:"upstreams"`
 	BlockListURLs      []string     `json:"blocklist_urls"`
+	NoiseFilterURLs    []string     `json:"noise_filter_urls"`
 	AllowedHosts       []string     `json:"allowed_hosts"`
 	MetricsAuth        string       `json:"-"`
 	MaxCacheSize       int          `json:"max_cache_size"`
@@ -170,6 +172,24 @@ func (app *App) RunServer(ctx context.Context) error {
 	if _, err = crontab.AddJob(app.CronSchedule.Downloader, blocklistUpdater); err != nil {
 		return errors.Wrap(err, "failed to create blocklist downloader cron job")
 	}
+
+	noiseFilter := noisefilter.NewNoiseFilter()
+	noiseFilterPath := fmt.Sprintf("%s/noise-filter.csv", app.DataDir)
+	if err := noiseFilter.LoadFromFile(noiseFilterPath); err != nil {
+		app.Logger.Warn("Could not load noise filter from local file", "path", noiseFilterPath, "error", err)
+	}
+
+	for _, url := range app.NoiseFilterURLs {
+		if err := noisefilter.Fetch(url, noiseFilter, app.Logger); err != nil {
+			app.Logger.Error("failed to download noise filter", "url", url, "error", err)
+		}
+	}
+
+	app.Logger.Info("Creating noise filter downloader cron job", "schedule", app.CronSchedule.Downloader)
+	noiseFilterUpdater := noisefilter.NewNoiseFilterUpdater(noiseFilter, app.NoiseFilterURLs, app.Logger)
+	if _, err = crontab.AddJob(app.CronSchedule.Downloader, noiseFilterUpdater); err != nil {
+		return errors.Wrap(err, "failed to create noise filter downloader cron job")
+	}
 	certCacheDir := fmt.Sprintf("%s/certcache", app.DataDir)
 	if err := os.MkdirAll(certCacheDir, 0700); err != nil {
 		return errors.Wrap(err, "failed to create certcache directory")
@@ -209,7 +229,7 @@ func (app *App) RunServer(ctx context.Context) error {
 		return errors.Wrap(err, "failed to initialize upstream DNS client")
 	}
 
-	dispatcher, err := forwarder.NewDNSDispatcher(cache, metrics, dnsClient, blockList, app.CacheTtlFloor, app.Logger, app.EnableECS)
+	dispatcher, err := forwarder.NewDNSDispatcher(cache, metrics, dnsClient, blockList, noiseFilter, app.CacheTtlFloor, app.Logger, app.EnableECS)
 	if err != nil {
 		return errors.Wrap(err, "failed to create dispatcher")
 	}

--- a/internal/app.go
+++ b/internal/app.go
@@ -51,8 +51,8 @@ type App struct {
 	DotPort            int          `json:"dot_port"`
 	Upstreams          []string     `json:"upstreams"`
 	BlockListURLs      []string     `json:"blocklist_urls"`
-	NoiseFilterURLs    []string     `json:"noise_filter_urls"`
 	AllowedHosts       []string     `json:"allowed_hosts"`
+	NoiseFilterURL     string       `json:"noise_filter_url"`
 	MetricsAuth        string       `json:"-"`
 	MaxCacheSize       int          `json:"max_cache_size"`
 	DisableIp2Location bool         `json:"disable_ip2location"`
@@ -174,19 +174,12 @@ func (app *App) RunServer(ctx context.Context) error {
 	}
 
 	noiseFilter := noisefilter.NewNoiseFilter()
-	noiseFilterPath := fmt.Sprintf("%s/noise-filter.csv", app.DataDir)
-	if err := noiseFilter.LoadFromFile(noiseFilterPath); err != nil {
-		app.Logger.Warn("Could not load noise filter from local file", "path", noiseFilterPath, "error", err)
-	}
-
-	for _, url := range app.NoiseFilterURLs {
-		if err := noisefilter.Fetch(url, noiseFilter, app.Logger); err != nil {
-			app.Logger.Error("failed to download noise filter", "url", url, "error", err)
-		}
+	if err := noisefilter.Fetch(app.NoiseFilterURL, noiseFilter, app.Logger); err != nil {
+		app.Logger.Error("failed to download noise filter", "url", app.NoiseFilterURL, "error", err)
 	}
 
 	app.Logger.Info("Creating noise filter downloader cron job", "schedule", app.CronSchedule.Downloader)
-	noiseFilterUpdater := noisefilter.NewNoiseFilterUpdater(noiseFilter, app.NoiseFilterURLs, app.Logger)
+	noiseFilterUpdater := noisefilter.NewNoiseFilterUpdater(noiseFilter, app.NoiseFilterURL, app.Logger)
 	if _, err = crontab.AddJob(app.CronSchedule.Downloader, noiseFilterUpdater); err != nil {
 		return errors.Wrap(err, "failed to create noise filter downloader cron job")
 	}

--- a/internal/forwarder/dispatcher.go
+++ b/internal/forwarder/dispatcher.go
@@ -11,6 +11,7 @@ import (
 	"github.com/miekg/dns"
 	"github.com/rm-hull/dot-block/internal/blocklist"
 	"github.com/rm-hull/dot-block/internal/metrics"
+	"github.com/rm-hull/dot-block/internal/noisefilter"
 	"github.com/rm-hull/dot-block/internal/telemetry"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
@@ -54,6 +55,7 @@ type DNSDispatcher struct {
 	blockList  *blocklist.BlockList
 	metrics    *metrics.DnsMetrics
 	logger     *slog.Logger
+	noiseFilter *noisefilter.NoiseFilter
 	enableECS  bool
 	snapshotCh chan *metrics.RequestSnapshot
 	done       chan struct{}
@@ -64,6 +66,7 @@ func NewDNSDispatcher(
 	dnsMetrics *metrics.DnsMetrics,
 	dnsClient *RoundRobinClient,
 	blockList *blocklist.BlockList,
+	noiseFilter *noisefilter.NoiseFilter,
 	ttlFloor time.Duration,
 	logger *slog.Logger,
 	enableECS bool,
@@ -81,6 +84,7 @@ func NewDNSDispatcher(
 		blockList:  blockList,
 		metrics:    dnsMetrics,
 		logger:     logger,
+		noiseFilter: noiseFilter,
 		enableECS:  enableECS,
 		snapshotCh: make(chan *metrics.RequestSnapshot, SNAPSHOT_BUFFER_SIZE),
 		done:       make(chan struct{}),
@@ -176,7 +180,7 @@ func (d *DNSDispatcher) HandleDNSRequest(source DNSSource) DispatcherFunc {
 			rcode, answers, err := d.resolveUpstream(requestCtx, unansweredQuestions, req)
 			if err != nil {
 				resp.Rcode = rcode
-				d.reportError(requestCtx, "upstream", err, "qtype", getQueryType(&unansweredQuestions[0]))
+				d.reportError(requestCtx, "upstream", err, unansweredQuestions[0].Name, "qtype", getQueryType(&unansweredQuestions[0]))
 				d.sendResponse(requestCtx, writer, resp)
 				return
 			}
@@ -225,7 +229,7 @@ func (d *DNSDispatcher) processQuestion(requestCtx *RequestContext, q *dns.Quest
 	if err != nil {
 		span.RecordError(err)
 		span.SetStatus(codes.Error, err.Error())
-		d.reportError(requestCtx, "blocklist", err, "qtype", queryType)
+		d.reportError(requestCtx, "blocklist", err, q.Name, "qtype", queryType)
 		return nil, dns.RcodeServerFailure, err
 	}
 
@@ -453,7 +457,20 @@ func (d *DNSDispatcher) isFreshnessSensitive(q *dns.Question) bool {
 	return false
 }
 
-func (d *DNSDispatcher) reportError(requestCtx *RequestContext, errorCategory string, err error, additionalFields ...any) {
+func (d *DNSDispatcher) reportError(requestCtx *RequestContext, errorCategory string, err error, domain string, additionalFields ...any) {
+	if d.noiseFilter != nil {
+		rcodeStr := ""
+		var rcodeErr *RcodeError
+		if errors.As(err, &rcodeErr) {
+			rcodeStr = dns.RcodeToString[rcodeErr.Rcode]
+		}
+
+		if d.noiseFilter.ShouldSuppress(errorCategory, rcodeStr, domain) {
+			requestCtx.snapshot.SetErrorCategory(errorCategory)
+			return
+		}
+	}
+
 	if ShouldLog(err) {
 		args := append(additionalFields,
 			"category", errorCategory,
@@ -490,7 +507,7 @@ func (d *DNSDispatcher) forwardQuery(requestCtx *RequestContext, req *dns.Msg) (
 func (d *DNSDispatcher) sendResponse(ctx *RequestContext, writer dns.ResponseWriter, msg *dns.Msg) {
 	ctx.snapshot.SetRcode(dns.RcodeToString[msg.Rcode])
 	if err := writer.WriteMsg(msg); err != nil {
-		d.reportError(ctx, "response", err)
+		d.reportError(ctx, "response", err, "", "")
 		return
 	}
 }

--- a/internal/forwarder/dispatcher.go
+++ b/internal/forwarder/dispatcher.go
@@ -2,6 +2,7 @@ package forwarder
 
 import (
 	"context"
+	"fmt"
 	"log/slog"
 	"net"
 	"strings"
@@ -472,15 +473,15 @@ func (d *DNSDispatcher) reportError(requestCtx *RequestContext, errorCategory st
 	}
 
 	if ShouldLog(err) {
+		// Ensure args are in key-value pairs for slog
+		if len(additionalFields)%2 != 0 {
+			panic(fmt.Sprintf("additionalFields must be in key-value pairs: %v", additionalFields))
+		}
+
 		args := append(additionalFields,
 			"category", errorCategory,
 			"error", err,
 			"latency", requestCtx.snapshot.Latency().String())
-
-		// Ensure args are in key-value pairs for slog
-		if len(args)%2 != 0 {
-			args = append(args, "unbalanced_args")
-		}
 
 		requestCtx.logger.ErrorContext(requestCtx.ctx, "DNS error", args...)
 	}
@@ -512,7 +513,7 @@ func (d *DNSDispatcher) forwardQuery(requestCtx *RequestContext, req *dns.Msg) (
 func (d *DNSDispatcher) sendResponse(ctx *RequestContext, writer dns.ResponseWriter, msg *dns.Msg) {
 	ctx.snapshot.SetRcode(dns.RcodeToString[msg.Rcode])
 	if err := writer.WriteMsg(msg); err != nil {
-		d.reportError(ctx, "response", err, "", "")
+		d.reportError(ctx, "response", err, "")
 		return
 	}
 }

--- a/internal/forwarder/dispatcher.go
+++ b/internal/forwarder/dispatcher.go
@@ -48,17 +48,17 @@ type RequestContext struct {
 type DispatcherFunc func(writer dns.ResponseWriter, req *dns.Msg)
 
 type DNSDispatcher struct {
-	dnsClient  *RoundRobinClient
-	defaultTTL float64
-	ttlFloor   time.Duration
-	cache      *DNSCache
-	blockList  *blocklist.BlockList
-	metrics    *metrics.DnsMetrics
-	logger     *slog.Logger
+	dnsClient   *RoundRobinClient
+	defaultTTL  float64
+	ttlFloor    time.Duration
+	cache       *DNSCache
+	blockList   *blocklist.BlockList
+	metrics     *metrics.DnsMetrics
+	logger      *slog.Logger
 	noiseFilter *noisefilter.NoiseFilter
-	enableECS  bool
-	snapshotCh chan *metrics.RequestSnapshot
-	done       chan struct{}
+	enableECS   bool
+	snapshotCh  chan *metrics.RequestSnapshot
+	done        chan struct{}
 }
 
 func NewDNSDispatcher(
@@ -77,17 +77,17 @@ func NewDNSDispatcher(
 	}
 
 	d := &DNSDispatcher{
-		dnsClient:  dnsClient,
-		defaultTTL: 300, // TODO: pass in
-		ttlFloor:   ttlFloor,
-		cache:      cache,
-		blockList:  blockList,
-		metrics:    dnsMetrics,
-		logger:     logger,
+		dnsClient:   dnsClient,
+		defaultTTL:  300, // TODO: pass in
+		ttlFloor:    ttlFloor,
+		cache:       cache,
+		blockList:   blockList,
+		metrics:     dnsMetrics,
+		logger:      logger,
 		noiseFilter: noiseFilter,
-		enableECS:  enableECS,
-		snapshotCh: make(chan *metrics.RequestSnapshot, SNAPSHOT_BUFFER_SIZE),
-		done:       make(chan struct{}),
+		enableECS:   enableECS,
+		snapshotCh:  make(chan *metrics.RequestSnapshot, SNAPSHOT_BUFFER_SIZE),
+		done:        make(chan struct{}),
 	}
 
 	for range NUM_WORKERS {
@@ -476,6 +476,11 @@ func (d *DNSDispatcher) reportError(requestCtx *RequestContext, errorCategory st
 			"category", errorCategory,
 			"error", err,
 			"latency", requestCtx.snapshot.Latency().String())
+
+		// Ensure args are in key-value pairs for slog
+		if len(args)%2 != 0 {
+			args = append(args, "unbalanced_args")
+		}
 
 		requestCtx.logger.ErrorContext(requestCtx.ctx, "DNS error", args...)
 	}

--- a/internal/forwarder/dispatcher_test.go
+++ b/internal/forwarder/dispatcher_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/miekg/dns"
 	"github.com/rm-hull/dot-block/internal/blocklist"
 	"github.com/rm-hull/dot-block/internal/metrics"
+	"github.com/rm-hull/dot-block/internal/noisefilter"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
@@ -94,7 +95,7 @@ func setupDispatcherTest(t *testing.T, upstream string, logger *slog.Logger, ena
 	dnsClient, err := NewRoundRobinClient(metrics, 2*time.Second, 2*time.Second, 2*time.Second, logger, upstream)
 	require.NoError(t, err)
 
-	dispatcher, err := NewDNSDispatcher(cache, metrics, dnsClient, blockList, 1*time.Minute, logger, enableECS)
+	dispatcher, err := NewDNSDispatcher(cache, metrics, dnsClient, blockList, noisefilter.NewNoiseFilter(), 1*time.Minute, logger, enableECS)
 	require.NoError(t, err)
 	t.Cleanup(dispatcher.Close)
 
@@ -341,7 +342,7 @@ func TestDNSDispatcher_NegativeCacheTtlFloor(t *testing.T) {
 	dnsClient, err := NewRoundRobinClient(metrics, 2*time.Second, 2*time.Second, 2*time.Second, logger, "8.8.8.8:53")
 	assert.NoError(t, err)
 
-	dispatcher, err := NewDNSDispatcher(cache, metrics, dnsClient, blockList, -1*time.Second, logger, false)
+	dispatcher, err := NewDNSDispatcher(cache, metrics, dnsClient, blockList, noisefilter.NewNoiseFilter(), -1*time.Second, logger, false)
 	assert.Error(t, err)
 	assert.Nil(t, dispatcher)
 	assert.Contains(t, err.Error(), "TTL floor cannot be negative")
@@ -667,7 +668,7 @@ func TestDNSDispatcher_ECS_Injection(t *testing.T) {
 			metrics, _ := metrics.NewDNSMetrics(cache, mockGeo)
 			dnsClient, _ := NewRoundRobinClient(metrics, 2*time.Second, 2*time.Second, 2*time.Second, logger, upstream)
 
-			dispatcher, _ := NewDNSDispatcher(cache, metrics, dnsClient, blockList, 1*time.Minute, logger, tt.enableECS)
+			dispatcher, _ := NewDNSDispatcher(cache, metrics, dnsClient, blockList, noisefilter.NewNoiseFilter(), 1*time.Minute, logger, tt.enableECS)
 			defer dispatcher.Close()
 
 			// Mock ResponseWriter with the specific client IP

--- a/internal/integration_test.go
+++ b/internal/integration_test.go
@@ -28,6 +28,7 @@ func TestIntegration_DNSFunctionality(t *testing.T) {
 		Upstreams:          []string{"8.8.8.8", "1.1.1.1"},
 		BlockListURLs:      []string{"file://../data/blocklist.txt"},
 		AllowedHosts:       []string{"example.com"},
+		NoiseFilterURL:     "file://../data/noise-filter.csv",
 		DataDir:            "../data",
 		DisableIp2Location: true,
 		MaxCacheSize:       1000,

--- a/internal/noisefilter/noisefilter.go
+++ b/internal/noisefilter/noisefilter.go
@@ -70,7 +70,7 @@ func (nf *NoiseFilter) LoadFromFile(path string) error {
 	if err != nil {
 		return err
 	}
-	defer f.Close()
+	defer func() { _ = f.Close() }()
 
 	return nf.Load(f)
 }

--- a/internal/noisefilter/noisefilter.go
+++ b/internal/noisefilter/noisefilter.go
@@ -4,7 +4,6 @@ import (
 	"encoding/csv"
 	"fmt"
 	"io"
-	"os"
 	"strings"
 	"sync"
 )
@@ -36,7 +35,7 @@ func (nf *NoiseFilter) Load(reader io.Reader) error {
 	csvReader := csv.NewReader(reader)
 
 	// Detect and skip header
-	firstRecord, err := csvReader.Read()
+	_, err := csvReader.Read()
 	if err != nil {
 		if err == io.EOF {
 			return nil
@@ -44,15 +43,8 @@ func (nf *NoiseFilter) Load(reader io.Reader) error {
 		return fmt.Errorf("failed to read CSV: %w", err)
 	}
 
-	// Simple header detection: if the first column is "category", it's a header
-	if len(firstRecord) > 0 && strings.ToLower(strings.TrimSpace(firstRecord[0])) == "category" {
-		// It's a header, we already read it, so we just continue
-	} else {
-		// Not a header, we need to process this first record as a rule
-		nf.mu.Lock()
-		nf.appendTriplet(firstRecord)
-		nf.mu.Unlock()
-	}
+	nf.mu.Lock()
+	defer nf.mu.Unlock()
 
 	for {
 		record, err := csvReader.Read()
@@ -67,9 +59,7 @@ func (nf *NoiseFilter) Load(reader io.Reader) error {
 			continue // Skip malformed lines
 		}
 
-		nf.mu.Lock()
 		nf.appendTriplet(record)
-		nf.mu.Unlock()
 	}
 
 	return nil
@@ -86,16 +76,6 @@ func (nf *NoiseFilter) appendTriplet(record []string) {
 		Rcode:        strings.ToUpper(strings.TrimSpace(record[1])),
 		DomainSuffix: suffix,
 	})
-}
-
-func (nf *NoiseFilter) LoadFromFile(path string) error {
-	f, err := os.Open(path)
-	if err != nil {
-		return err
-	}
-	defer func() { _ = f.Close() }()
-
-	return nf.Load(f)
 }
 
 func (nf *NoiseFilter) ShouldSuppress(category, rcode, domain string) bool {

--- a/internal/noisefilter/noisefilter.go
+++ b/internal/noisefilter/noisefilter.go
@@ -1,0 +1,89 @@
+package noisefilter
+
+import (
+	"encoding/csv"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+	"sync"
+)
+
+type Triplet struct {
+	Category     string
+	Rcode        string
+	DomainSuffix string
+}
+
+type NoiseFilter struct {
+	mu       sync.RWMutex
+	triplets []Triplet
+}
+
+func NewNoiseFilter() *NoiseFilter {
+	return &NoiseFilter{
+		triplets: make([]Triplet, 0),
+	}
+}
+
+func (nf *NoiseFilter) Load(reader io.Reader) error {
+	csvReader := csv.NewReader(reader)
+	
+	// Skip header
+	if _, err := csvReader.Read(); err != nil {
+		if err == io.EOF {
+			return nil
+		}
+		return fmt.Errorf("failed to read CSV header: %w", err)
+	}
+
+	var newTriplets []Triplet
+	for {
+		record, err := csvReader.Read()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return fmt.Errorf("failed to read CSV record: %w", err)
+		}
+
+		if len(record) < 3 {
+			continue // Skip malformed lines
+		}
+
+		newTriplets = append(newTriplets, Triplet{
+			Category:     strings.TrimSpace(record[0]),
+			Rcode:        strings.TrimSpace(record[1]),
+			DomainSuffix: strings.TrimSpace(record[2]),
+		})
+	}
+
+	nf.mu.Lock()
+	nf.triplets = newTriplets
+	nf.mu.Unlock()
+
+	return nil
+}
+
+func (nf *NoiseFilter) LoadFromFile(path string) error {
+	f, err := os.Open(path)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	return nf.Load(f)
+}
+
+func (nf *NoiseFilter) ShouldSuppress(category, rcode, domain string) bool {
+	nf.mu.RLock()
+	defer nf.mu.RUnlock()
+
+	for _, t := range nf.triplets {
+		if t.Category == category && t.Rcode == rcode && strings.HasSuffix(domain, t.DomainSuffix) {
+			return true
+		}
+	}
+
+	return false
+}

--- a/internal/noisefilter/noisefilter.go
+++ b/internal/noisefilter/noisefilter.go
@@ -26,18 +26,34 @@ func NewNoiseFilter() *NoiseFilter {
 	}
 }
 
+func (nf *NoiseFilter) Reset() {
+	nf.mu.Lock()
+	defer nf.mu.Unlock()
+	nf.triplets = make([]Triplet, 0)
+}
+
 func (nf *NoiseFilter) Load(reader io.Reader) error {
 	csvReader := csv.NewReader(reader)
-	
-	// Skip header
-	if _, err := csvReader.Read(); err != nil {
+
+	// Detect and skip header
+	firstRecord, err := csvReader.Read()
+	if err != nil {
 		if err == io.EOF {
 			return nil
 		}
-		return fmt.Errorf("failed to read CSV header: %w", err)
+		return fmt.Errorf("failed to read CSV: %w", err)
 	}
 
-	var newTriplets []Triplet
+	// Simple header detection: if the first column is "category", it's a header
+	if len(firstRecord) > 0 && strings.ToLower(strings.TrimSpace(firstRecord[0])) == "category" {
+		// It's a header, we already read it, so we just continue
+	} else {
+		// Not a header, we need to process this first record as a rule
+		nf.mu.Lock()
+		nf.appendTriplet(firstRecord)
+		nf.mu.Unlock()
+	}
+
 	for {
 		record, err := csvReader.Read()
 		if err == io.EOF {
@@ -51,18 +67,25 @@ func (nf *NoiseFilter) Load(reader io.Reader) error {
 			continue // Skip malformed lines
 		}
 
-		newTriplets = append(newTriplets, Triplet{
-			Category:     strings.TrimSpace(record[0]),
-			Rcode:        strings.TrimSpace(record[1]),
-			DomainSuffix: strings.TrimSpace(record[2]),
-		})
+		nf.mu.Lock()
+		nf.appendTriplet(record)
+		nf.mu.Unlock()
 	}
 
-	nf.mu.Lock()
-	nf.triplets = newTriplets
-	nf.mu.Unlock()
-
 	return nil
+}
+
+func (nf *NoiseFilter) appendTriplet(record []string) {
+	suffix := strings.TrimSpace(record[2])
+	if suffix != "" && !strings.HasSuffix(suffix, ".") {
+		suffix += "."
+	}
+
+	nf.triplets = append(nf.triplets, Triplet{
+		Category:     strings.ToUpper(strings.TrimSpace(record[0])),
+		Rcode:        strings.ToUpper(strings.TrimSpace(record[1])),
+		DomainSuffix: suffix,
+	})
 }
 
 func (nf *NoiseFilter) LoadFromFile(path string) error {
@@ -76,12 +99,21 @@ func (nf *NoiseFilter) LoadFromFile(path string) error {
 }
 
 func (nf *NoiseFilter) ShouldSuppress(category, rcode, domain string) bool {
+	if !strings.HasSuffix(domain, ".") {
+		domain += "."
+	}
+
+	category = strings.ToUpper(category)
+	rcode = strings.ToUpper(rcode)
+
 	nf.mu.RLock()
 	defer nf.mu.RUnlock()
 
 	for _, t := range nf.triplets {
-		if t.Category == category && t.Rcode == rcode && strings.HasSuffix(domain, t.DomainSuffix) {
-			return true
+		if t.Category == category && t.Rcode == rcode {
+			if domain == t.DomainSuffix || strings.HasSuffix(domain, "."+t.DomainSuffix) {
+				return true
+			}
 		}
 	}
 

--- a/internal/noisefilter/noisefilter_test.go
+++ b/internal/noisefilter/noisefilter_test.go
@@ -67,8 +67,8 @@ func TestNoiseFilter_ShouldSuppress(t *testing.T) {
 			expectSuppress: false,
 		},
 		{
-			name: "Empty filter - should NOT suppress",
-			triplets: []Triplet{},
+			name:           "Empty filter - should NOT suppress",
+			triplets:       []Triplet{},
 			category:       "upstream",
 			rcode:          "REFUSED",
 			domain:         "test.akadns.net",
@@ -79,8 +79,23 @@ func TestNoiseFilter_ShouldSuppress(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			nf := NewNoiseFilter()
+
+			// Normalize triplets as Load would
+			normalizedTriplets := make([]Triplet, 0, len(tt.triplets))
+			for _, tr := range tt.triplets {
+				suffix := tr.DomainSuffix
+				if suffix != "" && !strings.HasSuffix(suffix, ".") {
+					suffix += "."
+				}
+				normalizedTriplets = append(normalizedTriplets, Triplet{
+					Category:     strings.ToUpper(tr.Category),
+					Rcode:        strings.ToUpper(tr.Rcode),
+					DomainSuffix: suffix,
+				})
+			}
+
 			nf.mu.Lock()
-			nf.triplets = tt.triplets
+			nf.triplets = normalizedTriplets
 			nf.mu.Unlock()
 
 			assert.Equal(t, tt.expectSuppress, nf.ShouldSuppress(tt.category, tt.rcode, tt.domain))

--- a/internal/noisefilter/noisefilter_test.go
+++ b/internal/noisefilter/noisefilter_test.go
@@ -1,0 +1,106 @@
+package noisefilter
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNoiseFilter_ShouldSuppress(t *testing.T) {
+	tests := []struct {
+		name           string
+		triplets       []Triplet
+		category       string
+		rcode          string
+		domain         string
+		expectSuppress bool
+	}{
+		{
+			name: "Exact match - should suppress",
+			triplets: []Triplet{
+				{Category: "upstream", Rcode: "REFUSED", DomainSuffix: "akadns.net"},
+			},
+			category:       "upstream",
+			rcode:          "REFUSED",
+			domain:         "test.akadns.net",
+			expectSuppress: true,
+		},
+		{
+			name: "Exact match - different subdomain - should suppress",
+			triplets: []Triplet{
+				{Category: "upstream", Rcode: "REFUSED", DomainSuffix: "akadns.net"},
+			},
+			category:       "upstream",
+			rcode:          "REFUSED",
+			domain:         "sub.test.akadns.net",
+			expectSuppress: true,
+		},
+		{
+			name: "Wrong category - should NOT suppress",
+			triplets: []Triplet{
+				{Category: "upstream", Rcode: "REFUSED", DomainSuffix: "akadns.net"},
+			},
+			category:       "blocklist",
+			rcode:          "REFUSED",
+			domain:         "test.akadns.net",
+			expectSuppress: false,
+		},
+		{
+			name: "Wrong rcode - should NOT suppress",
+			triplets: []Triplet{
+				{Category: "upstream", Rcode: "REFUSED", DomainSuffix: "akadns.net"},
+			},
+			category:       "upstream",
+			rcode:          "SERVFAIL",
+			domain:         "test.akadns.net",
+			expectSuppress: false,
+		},
+		{
+			name: "Wrong domain suffix - should NOT suppress",
+			triplets: []Triplet{
+				{Category: "upstream", Rcode: "REFUSED", DomainSuffix: "akadns.net"},
+			},
+			category:       "upstream",
+			rcode:          "REFUSED",
+			domain:         "test.google.com",
+			expectSuppress: false,
+		},
+		{
+			name: "Empty filter - should NOT suppress",
+			triplets: []Triplet{},
+			category:       "upstream",
+			rcode:          "REFUSED",
+			domain:         "test.akadns.net",
+			expectSuppress: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			nf := NewNoiseFilter()
+			nf.mu.Lock()
+			nf.triplets = tt.triplets
+			nf.mu.Unlock()
+
+			assert.Equal(t, tt.expectSuppress, nf.ShouldSuppress(tt.category, tt.rcode, tt.domain))
+		})
+	}
+}
+
+func TestNoiseFilter_Load(t *testing.T) {
+	csvData := `category,rcode,domain_suffix
+upstream,REFUSED,akadns.net
+upstream,REFUSED,akamaiedge.net
+blocklist,ERROR,example.com
+`
+	reader := strings.NewReader(csvData)
+	nf := NewNoiseFilter()
+	err := nf.Load(reader)
+	assert.NoError(t, err)
+
+	assert.True(t, nf.ShouldSuppress("upstream", "REFUSED", "test.akadns.net"))
+	assert.True(t, nf.ShouldSuppress("upstream", "REFUSED", "test.akamaiedge.net"))
+	assert.True(t, nf.ShouldSuppress("blocklist", "ERROR", "test.example.com"))
+	assert.False(t, nf.ShouldSuppress("upstream", "REFUSED", "test.google.com"))
+}

--- a/internal/noisefilter/update.go
+++ b/internal/noisefilter/update.go
@@ -10,26 +10,23 @@ import (
 
 type NoiseFilterUpdater struct {
 	NoiseFilter *NoiseFilter
-	URLs        []string
+	URL         string
 	Logger      *slog.Logger
 }
 
-func NewNoiseFilterUpdater(nf *NoiseFilter, urls []string, logger *slog.Logger) *NoiseFilterUpdater {
+func NewNoiseFilterUpdater(nf *NoiseFilter, url string, logger *slog.Logger) *NoiseFilterUpdater {
 	return &NoiseFilterUpdater{
 		NoiseFilter: nf,
-		URLs:        urls,
+		URL:         url,
 		Logger:      logger,
 	}
 }
 
 func (job *NoiseFilterUpdater) Run() {
 	job.NoiseFilter.Reset()
-	for _, url := range job.URLs {
-		err := Fetch(url, job.NoiseFilter, job.Logger)
-		if err != nil {
-			job.Logger.Error("failed to download noise filter for cron reload", "error", err, "url", url)
-			continue
-		}
+	err := Fetch(job.URL, job.NoiseFilter, job.Logger)
+	if err != nil {
+		job.Logger.Error("failed to download noise filter for cron reload", "error", err, "url", job.URL)
 	}
 }
 
@@ -49,7 +46,7 @@ func Fetch(url string, nf *NoiseFilter, logger *slog.Logger) error {
 	})
 
 	if err == nil {
-		logger.Info("Noise filter loaded successfully")
+		logger.Info("Noise filter loaded successfully", "count", len(nf.triplets))
 	}
 	return err
 }

--- a/internal/noisefilter/update.go
+++ b/internal/noisefilter/update.go
@@ -23,6 +23,7 @@ func NewNoiseFilterUpdater(nf *NoiseFilter, urls []string, logger *slog.Logger) 
 }
 
 func (job *NoiseFilterUpdater) Run() {
+	job.NoiseFilter.Reset()
 	for _, url := range job.URLs {
 		err := Fetch(url, job.NoiseFilter, job.Logger)
 		if err != nil {

--- a/internal/noisefilter/update.go
+++ b/internal/noisefilter/update.go
@@ -1,0 +1,54 @@
+package noisefilter
+
+import (
+	"log/slog"
+	"net/http"
+	"os"
+
+	"github.com/rm-hull/dot-block/internal/downloader"
+)
+
+type NoiseFilterUpdater struct {
+	NoiseFilter *NoiseFilter
+	URLs        []string
+	Logger      *slog.Logger
+}
+
+func NewNoiseFilterUpdater(nf *NoiseFilter, urls []string, logger *slog.Logger) *NoiseFilterUpdater {
+	return &NoiseFilterUpdater{
+		NoiseFilter: nf,
+		URLs:        urls,
+		Logger:      logger,
+	}
+}
+
+func (job *NoiseFilterUpdater) Run() {
+	for _, url := range job.URLs {
+		err := Fetch(url, job.NoiseFilter, job.Logger)
+		if err != nil {
+			job.Logger.Error("failed to download noise filter for cron reload", "error", err, "url", url)
+			continue
+		}
+	}
+}
+
+func Fetch(url string, nf *NoiseFilter, logger *slog.Logger) error {
+	err := downloader.TransientDownload(logger, "noisefilter", url, "", func(tmpFile string, header http.Header) error {
+		f, err := os.Open(tmpFile)
+		if err != nil {
+			return err
+		}
+		defer f.Close()
+
+		if err := nf.Load(f); err != nil {
+			return err
+		}
+
+		return nil
+	})
+
+	if err == nil {
+		logger.Info("Noise filter loaded successfully")
+	}
+	return err
+}

--- a/internal/noisefilter/update.go
+++ b/internal/noisefilter/update.go
@@ -38,7 +38,7 @@ func Fetch(url string, nf *NoiseFilter, logger *slog.Logger) error {
 		if err != nil {
 			return err
 		}
-		defer f.Close()
+		defer func() { _ = f.Close() }()
 
 		if err := nf.Load(f); err != nil {
 			return err

--- a/main.go
+++ b/main.go
@@ -18,6 +18,8 @@ const DEFAULT_DOWNLOADER_CRON_SCHEDULE = "@every 19h"
 const DEFAULT_CACHE_REAPER_CRON_SCHEDULE = "0 3 * * *" // 3:00am every day
 const DEFAULT_IP2LOCATION_CRON_SCHEDULE = "5 7 4 * *"  // 7:05am on the 4th of every month
 
+var DEFAULT_NOISE_FILTER_URL = "https://raw.githubusercontent.com/rm-hull/dot-block/refs/heads/main/data/noise-filter.csv"
+
 var DEFAULT_BLOCKLIST_URLS = []string{
 	"https://codeberg.org/hagezi/mirror2/raw/branch/main/dns-blocklists/hosts/pro.txt",       // Hagezi Pro blocklist
 	"https://raw.githubusercontent.com/rm-hull/dot-block/refs/heads/main/data/blocklist.txt", // dot-block default blocklist
@@ -92,7 +94,7 @@ func main() {
 
 	rootCmd.Flags().StringVar(&app.LogLevel, "log-level", "INFO", "Log level (DEBUG, INFO, WARN, ERROR)")
 	rootCmd.Flags().StringSliceVar(&app.BlockListURLs, "blocklist-url", DEFAULT_BLOCKLIST_URLS, "URL of blocklist, must be wildcard hostname format")
-	rootCmd.Flags().StringSliceVar(&app.NoiseFilterURLs, "noise-filter-url", nil, "URL of noise filter list (CSV format: category,rcode,domain_suffix)")
+	rootCmd.Flags().StringVar(&app.NoiseFilterURL, "noise-filter-url", DEFAULT_NOISE_FILTER_URL, "URL of noise filter list (CSV format: category,rcode,domain_suffix)")
 	rootCmd.Flags().StringVar(&app.DataDir, "data-dir", "./data", "Directory for persisting data (e.g. TLS certificate cache)")
 	rootCmd.Flags().BoolVar(&app.DevMode, "dev-mode", envDevMode, "Run server in dev mode (no TLS, plain TCP)")
 	rootCmd.Flags().IntVar(&dnsPort, "dns-port", 0, "The port to run regular DNS (UDP/TCP) server on")

--- a/main.go
+++ b/main.go
@@ -92,6 +92,7 @@ func main() {
 
 	rootCmd.Flags().StringVar(&app.LogLevel, "log-level", "INFO", "Log level (DEBUG, INFO, WARN, ERROR)")
 	rootCmd.Flags().StringSliceVar(&app.BlockListURLs, "blocklist-url", DEFAULT_BLOCKLIST_URLS, "URL of blocklist, must be wildcard hostname format")
+	rootCmd.Flags().StringSliceVar(&app.NoiseFilterURLs, "noise-filter-url", nil, "URL of noise filter list (CSV format: category,rcode,domain_suffix)")
 	rootCmd.Flags().StringVar(&app.DataDir, "data-dir", "./data", "Directory for persisting data (e.g. TLS certificate cache)")
 	rootCmd.Flags().BoolVar(&app.DevMode, "dev-mode", envDevMode, "Run server in dev mode (no TLS, plain TCP)")
 	rootCmd.Flags().IntVar(&dnsPort, "dns-port", 0, "The port to run regular DNS (UDP/TCP) server on")


### PR DESCRIPTION
### Problem
When EDNS Client Subnet (ECS) is enabled, upstream resolvers (like Google 8.8.8.8) forward the client's network prefix to authoritative name servers. While this is intended to improve latency by directing users to the closest edge node, it also allows authoritative servers to apply strict access control and geo-steering policies.

Specifically, Akamai-managed zones (e.g., `akadns.net`, `akamaiedge.net`) often return `Rcode: REFUSED` for production, sandbox, or regional endpoints when they detect the client is outside an authorized subnet. This results in a flood of "DNS error" logs in `dot-block`, even though the server is functioning correctly as a forwarder.

### Solution
This PR introduces a "Noise Filter" system that allows the server to suppress known-benign error logs based on a precise triplet of criteria.

#### Key Features:
- **Triplet-Based Filtering:** Logs are only suppressed if they match the specified `(Category, Rcode, DomainSuffix)`. This ensures that we don't accidentally hide real errors (like `TIMEOUT` or `SERVFAIL`) for the same domains.
- **Remote Configuration:** The filter list is stored in a CSV file and can be hosted on GitHub. The server downloads and reloads this list periodically, mirroring the existing blocklist update mechanism.
- **Fail-Safe Design:** The system is designed to "fail-open." If the filter list is missing, corrupted, or cannot be downloaded, the server continues to log all errors rather than suppressing them or crashing.
- **Zero Hardcoding:** No default filters are hardcoded into the source code; all suppression rules are driven by the configuration file.

#### Technical Implementation:
- **New Package `internal/noisefilter`**: Handles the loading, matching, and remote updating of the noise filter list.
- **Dispatcher Integration**: Modified `internal/forwarder/dispatcher.go` to inject the `NoiseFilter` into the `DNSDispatcher` and use it within `reportError`.
- **CLI Update**: Added a new flag `--noise-filter-url` to specify the location of the remote filter list.

#### Example Filter Entry:
```csv
category,rcode,domain_suffix
upstream,REFUSED,akadns.net
upstream,REFUSED,akamaiedge.net
```

### Verification
- Added comprehensive unit tests in `internal/noisefilter/noisefilter_test.go` covering various match/mismatch scenarios and CSV loading.
- Verified that the integration does not break existing DNS functionality via full test suite run.

Closes #152