### PR TITLE
feat: implement latency-aware upstream routing

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@ DoT Block is a high-performance, caching, and filtering DNS-over-TLS (DoT) serve
 -   **Easy to Deploy:** Can be run as a standalone binary or as a Docker container.
 -   **Automatic TLS:** Uses Let's Encrypt to automatically obtain and renew TLS certificates.
 -   **Advanced Observability:** Exports detailed Prometheus metrics including upstream health, failure reasons, and cache effectiveness.
+-   **Latency-Aware Routing:** Automatically prefers the fastest upstream resolvers based on real-time response latency and applies penalties to failing servers to ensure high availability.
+-   **Hardened TLS:** Uses a strict TLS configuration (TLS 1.2+) with forward-secrecy prioritized cipher suites to ensure maximum security for DoT connections.
 -   **Distributed Tracing:** Integrates with OpenTelemetry (OTel), providing end-to-end traces of DNS requests and correlating them with logs via `trace_id` and `span_id`.
 -   **Noise-Reduced Error Reporting:** Integrates with Sentry, with intelligent filtering to avoid logging protocol-valid negative responses (like NXDOMAIN or NOTIMP) as errors.
 -   **Proxy Protocol Support:** Supports PROXY protocol for DoT connections, enabling correct client IP identification when running behind a proxy.

--- a/docs/future-features.md
+++ b/docs/future-features.md
@@ -16,16 +16,10 @@ To prevent the server from being abused or becoming a vector for DNS amplificati
   - Implement token-bucket rate limiting in `HandleDNSRequest` to restrict the number of queries per second (QPS) from a single source IP.
 - **Response Rate Limiting (RRL):** 
   - Implement RRL to mitigate the risk of the server being used in DNS amplification DDoS attacks.
-- **Hardened TLS Configuration:** 
-  - Explicitly restrict TLS versions to 1.2 and 1.3.
-  - Enforce a strict set of cipher suites that prioritize Forward Secrecy (FS).
 
 ## ⚡ Performance: Intelligent Steering
-The current `RoundRobinClient` is simple and effective, but doesn't account for network conditions.
+The `RoundRobinClient` uses latency-based routing to account for network conditions.
 
-- **Latency-Based Routing:** 
-  - Track real-time response latencies for each configured upstream.
-  - Implement a weighted selection algorithm to prefer the fastest responding resolvers.
 - **Proactive Health Management:** 
   - Move health checks to a dedicated background worker.
   - Maintain a "Healthy Pool" of upstreams to avoid the latency penalty of discovering a failed server during a live client request.
@@ -48,6 +42,5 @@ Leveraging the existing HTTP infrastructure, `dot-block` can support a wider ran
 | :--- | :--- | :--- | :--- | :--- |
 | **Upstream DoT/DoH** | Privacy | Medium | **High** | End-to-End Privacy |
 | **Rate Limiting** | Security | Medium | **High** | Server Stability |
-| **Latency Steering** | Performance | Medium | Medium | Reduced Latency |
 | **DoH Support** | Feature | Low | Medium | Client Versatility |
 | **Proactive Health** | Performance | Low | Low | Reliable Failover |

--- a/internal/app.go
+++ b/internal/app.go
@@ -308,7 +308,6 @@ func (app *App) RunServer(ctx context.Context) error {
 			listener = tls.NewListener(proxyListener, &tls.Config{
 				MinVersion:               tls.VersionTLS12,
 				MaxVersion:               tls.VersionTLS13,
-				PreferServerCipherSuites: true,
 				CipherSuites: []uint16{
 					tls.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
 					tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,

--- a/internal/forwarder/dispatcher.go
+++ b/internal/forwarder/dispatcher.go
@@ -495,7 +495,6 @@ func (d *DNSDispatcher) forwardQuery(requestCtx *RequestContext, req *dns.Msg) (
 	_, span := tracer.Start(requestCtx.ctx, "forwardQuery")
 	defer span.End()
 
-	startTime := time.Now()
 	requestCtx.snapshot.Forwarded()
 	in, upstream, err := d.dnsClient.Exchange(req)
 
@@ -504,8 +503,6 @@ func (d *DNSDispatcher) forwardQuery(requestCtx *RequestContext, req *dns.Msg) (
 		span.SetStatus(codes.Error, err.Error())
 	}
 
-	duration := time.Since(startTime).Seconds()
-	requestCtx.snapshot.SetUpstream(upstream, duration)
 	span.SetAttributes(attribute.String("dns.upstream", upstream))
 
 	return in, upstream, err

--- a/internal/forwarder/round_robin_client.go
+++ b/internal/forwarder/round_robin_client.go
@@ -135,24 +135,24 @@ func (r *RoundRobinClient) selectUpstreamIndex() int {
 }
 
 func (r *RoundRobinClient) recordSuccess(server *upstreamServer, duration time.Duration) {
+	var newLat int64
 	for {
 		oldLat := server.latency.Load()
-		newLat := int64(float64(oldLat)*0.7 + float64(duration)*0.3)
+		newLat = int64(float64(oldLat)*0.7 + float64(duration)*0.3)
 		if server.latency.CompareAndSwap(oldLat, newLat) {
 			break
 		}
 	}
 
 	r.metrics.UpstreamLatency.WithLabelValues(server.config).Observe(duration.Seconds())
+	r.metrics.UpstreamEMA.WithLabelValues(server.config).Set(float64(newLat) / 1e9)
 }
 
 func (r *RoundRobinClient) recordFailure(server *upstreamServer, duration time.Duration, err error) {
+	var newLat int64
 	for {
 		oldLat := server.latency.Load()
-		newLat := oldLat + int64(500*time.Millisecond)
-		if newLat > int64(5*time.Second) {
-			newLat = int64(5 * time.Second)
-		}
+		newLat = min(oldLat+int64(500*time.Millisecond), int64(5*time.Second))
 		if server.latency.CompareAndSwap(oldLat, newLat) {
 			break
 		}
@@ -161,6 +161,7 @@ func (r *RoundRobinClient) recordFailure(server *upstreamServer, duration time.D
 	reason := getFailureReason(err)
 	r.metrics.UpstreamFailures.WithLabelValues(server.config, reason).Inc()
 	r.metrics.UpstreamLatency.WithLabelValues(server.config).Observe(duration.Seconds())
+	r.metrics.UpstreamEMA.WithLabelValues(server.config).Set(float64(newLat) / 1e9)
 	r.logger.Warn("upstream failure", "upstream", server.config, "reason", reason, "error", err)
 }
 

--- a/internal/forwarder/round_robin_client.go
+++ b/internal/forwarder/round_robin_client.go
@@ -145,14 +145,14 @@ func (r *RoundRobinClient) recordSuccess(server *upstreamServer, duration time.D
 	}
 
 	r.metrics.UpstreamLatency.WithLabelValues(server.config).Observe(duration.Seconds())
-	r.metrics.UpstreamEMA.WithLabelValues(server.config).Set(float64(newLat) / 1e9)
+	r.metrics.UpstreamEMA.WithLabelValues(server.config).Set(time.Duration(newLat).Seconds())
 }
 
 func (r *RoundRobinClient) recordFailure(server *upstreamServer, duration time.Duration, err error) {
 	var newLat int64
 	for {
 		oldLat := server.latency.Load()
-		newLat = min(oldLat+int64(500*time.Millisecond), int64(5*time.Second))
+		newLat = min(oldLat+int64(100*time.Millisecond), int64(5*time.Second))
 		if server.latency.CompareAndSwap(oldLat, newLat) {
 			break
 		}
@@ -161,7 +161,7 @@ func (r *RoundRobinClient) recordFailure(server *upstreamServer, duration time.D
 	reason := getFailureReason(err)
 	r.metrics.UpstreamFailures.WithLabelValues(server.config, reason).Inc()
 	r.metrics.UpstreamLatency.WithLabelValues(server.config).Observe(duration.Seconds())
-	r.metrics.UpstreamEMA.WithLabelValues(server.config).Set(float64(newLat) / 1e9)
+	r.metrics.UpstreamEMA.WithLabelValues(server.config).Set(time.Duration(newLat).Seconds())
 	r.logger.Warn("upstream failure", "upstream", server.config, "reason", reason, "error", err)
 }
 

--- a/internal/forwarder/round_robin_client.go
+++ b/internal/forwarder/round_robin_client.go
@@ -3,6 +3,7 @@ package forwarder
 import (
 	"context"
 	"log/slog"
+	"math/rand"
 	"net"
 	"sync/atomic"
 	"syscall"
@@ -15,13 +16,13 @@ import (
 )
 
 type upstreamServer struct {
-	config string
-	addr   string
+	config  string
+	addr    string
+	latency atomic.Int64 // nanoseconds, EMA
 }
 
 type RoundRobinClient struct {
 	upstreams []upstreamServer
-	counter   uint32
 	logger    *slog.Logger
 	metrics   *metrics.DnsMetrics
 	client    *dns.Client
@@ -64,7 +65,9 @@ func NewRoundRobinClient(metrics *metrics.DnsMetrics, readTimeout, writeTimeout,
 		if err != nil {
 			return nil, err
 		}
-		resolved = append(resolved, upstreamServer{config: config, addr: addr})
+		server := upstreamServer{config: config, addr: addr}
+		server.latency.Store(int64(100 * time.Millisecond))
+		resolved = append(resolved, server)
 	}
 
 	return &RoundRobinClient{
@@ -76,25 +79,79 @@ func NewRoundRobinClient(metrics *metrics.DnsMetrics, readTimeout, writeTimeout,
 }
 
 func (r *RoundRobinClient) Exchange(msg *dns.Msg) (*dns.Msg, string, error) {
-	n := uint32(len(r.upstreams))
-	start := uint32(atomic.AddUint32(&r.counter, 1) - 1)
+	n := len(r.upstreams)
+	if n == 0 {
+		return nil, "", errors.New("no upstreams available")
+	}
+
+	startIdx := r.selectUpstreamIndex()
 
 	var lastErr error
-	for i := range n {
-		server := r.upstreams[(start+i)%n]
+	for i := 0; i < n; i++ {
+		idx := (startIdx + i) % n
+		server := &r.upstreams[idx]
 
+		start := time.Now()
 		resp, _, err := r.client.Exchange(msg, server.addr)
+		duration := time.Since(start)
+
 		if err == nil {
+			r.recordSuccess(server, duration)
 			return resp, server.config, nil
 		}
 
-		reason := getFailureReason(err)
-		r.metrics.UpstreamFailures.WithLabelValues(server.config, reason).Inc()
-		r.logger.Warn("upstream failure", "upstream", server.config, "reason", reason, "error", err)
-
+		r.recordFailure(server, duration, err)
 		lastErr = errors.Wrapf(err, "upstream %s failed", server.config)
 	}
 	return nil, "", errors.Wrap(lastErr, "all upstream servers failed")
+}
+
+func (r *RoundRobinClient) selectUpstreamIndex() int {
+	n := len(r.upstreams)
+	weights := make([]float64, n)
+	var totalWeight float64
+	for i := range r.upstreams {
+		lat := r.upstreams[i].latency.Load()
+		if lat <= 0 {
+			lat = int64(time.Millisecond)
+		}
+		w := 1.0 / float64(lat)
+		weights[i] = w
+		totalWeight += w
+	}
+
+	randomVal := rand.Float64() * totalWeight
+	for i, w := range weights {
+		randomVal -= w
+		if randomVal <= 0 {
+			return i
+		}
+	}
+	return n - 1
+}
+
+func (r *RoundRobinClient) recordSuccess(server *upstreamServer, duration time.Duration) {
+	// Update latency using EMA: new = 0.7*old + 0.3*current
+	oldLat := server.latency.Load()
+	newLat := int64(float64(oldLat)*0.7 + float64(duration)*0.3)
+	server.latency.Store(newLat)
+
+	r.metrics.UpstreamLatency.WithLabelValues(server.config).Observe(duration.Seconds())
+}
+
+func (r *RoundRobinClient) recordFailure(server *upstreamServer, duration time.Duration, err error) {
+	// Apply penalty (increase latency)
+	oldLat := server.latency.Load()
+	newLat := oldLat + int64(500*time.Millisecond)
+	if newLat > int64(5*time.Second) {
+		newLat = int64(5 * time.Second)
+	}
+	server.latency.Store(newLat)
+
+	reason := getFailureReason(err)
+	r.metrics.UpstreamFailures.WithLabelValues(server.config, reason).Inc()
+	r.metrics.UpstreamLatency.WithLabelValues(server.config).Observe(duration.Seconds())
+	r.logger.Warn("upstream failure", "upstream", server.config, "reason", reason, "error", err)
 }
 
 func getFailureReason(err error) string {

--- a/internal/forwarder/round_robin_client.go
+++ b/internal/forwarder/round_robin_client.go
@@ -3,7 +3,7 @@ package forwarder
 import (
 	"context"
 	"log/slog"
-	"math/rand"
+	rand "math/rand/v2"
 	"net"
 	"sync/atomic"
 	"syscall"
@@ -18,7 +18,7 @@ import (
 type upstreamServer struct {
 	config  string
 	addr    string
-	latency atomic.Int64 // nanoseconds, EMA
+	latency *atomic.Int64 // nanoseconds, EMA
 }
 
 type RoundRobinClient struct {
@@ -65,7 +65,11 @@ func NewRoundRobinClient(metrics *metrics.DnsMetrics, readTimeout, writeTimeout,
 		if err != nil {
 			return nil, err
 		}
-		server := upstreamServer{config: config, addr: addr}
+		server := upstreamServer{
+			config:  config,
+			addr:    addr,
+			latency: new(atomic.Int64),
+		}
 		server.latency.Store(int64(100 * time.Millisecond))
 		resolved = append(resolved, server)
 	}
@@ -131,22 +135,28 @@ func (r *RoundRobinClient) selectUpstreamIndex() int {
 }
 
 func (r *RoundRobinClient) recordSuccess(server *upstreamServer, duration time.Duration) {
-	// Update latency using EMA: new = 0.7*old + 0.3*current
-	oldLat := server.latency.Load()
-	newLat := int64(float64(oldLat)*0.7 + float64(duration)*0.3)
-	server.latency.Store(newLat)
+	for {
+		oldLat := server.latency.Load()
+		newLat := int64(float64(oldLat)*0.7 + float64(duration)*0.3)
+		if server.latency.CompareAndSwap(oldLat, newLat) {
+			break
+		}
+	}
 
 	r.metrics.UpstreamLatency.WithLabelValues(server.config).Observe(duration.Seconds())
 }
 
 func (r *RoundRobinClient) recordFailure(server *upstreamServer, duration time.Duration, err error) {
-	// Apply penalty (increase latency)
-	oldLat := server.latency.Load()
-	newLat := oldLat + int64(500*time.Millisecond)
-	if newLat > int64(5*time.Second) {
-		newLat = int64(5 * time.Second)
+	for {
+		oldLat := server.latency.Load()
+		newLat := oldLat + int64(500*time.Millisecond)
+		if newLat > int64(5*time.Second) {
+			newLat = int64(5 * time.Second)
+		}
+		if server.latency.CompareAndSwap(oldLat, newLat) {
+			break
+		}
 	}
-	server.latency.Store(newLat)
 
 	reason := getFailureReason(err)
 	r.metrics.UpstreamFailures.WithLabelValues(server.config, reason).Inc()

--- a/internal/metrics/dns_metrics.go
+++ b/internal/metrics/dns_metrics.go
@@ -45,6 +45,7 @@ type DnsMetrics struct {
 	TopBlockedDomains   *SpaceSaver
 	UpstreamTTLs        *prometheus.HistogramVec
 	UpstreamLatency     *prometheus.HistogramVec
+	UpstreamEMA         *prometheus.GaugeVec
 	CacheReaperCalls    prometheus.Counter
 	DroppedCacheUpdates prometheus.Counter
 	DroppedTelemetry    prometheus.Counter
@@ -154,6 +155,11 @@ func NewDNSMetrics(cache Cache, geoIpLookup geoblock.GeoIpLookup) (*DnsMetrics, 
 		Buckets: latencyBuckets,
 	}, []string{"ip_addr"})
 
+	upstreamEMA := prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "dns_upstream_ema_seconds",
+		Help: "Exponential moving average of upstream DNS request latency, broken down by upstream server",
+	}, []string{"ip_addr"})
+
 	cacheReaperCalls := prometheus.NewCounter(prometheus.CounterOpts{
 		Name: "dns_cache_reaper_calls",
 		Help: "The number of times the cache reaper has been called",
@@ -198,6 +204,7 @@ func NewDNSMetrics(cache Cache, geoIpLookup geoblock.GeoIpLookup) (*DnsMetrics, 
 		topBlockedDomainsStats,
 		upstreamTTLs,
 		upstreamLatency,
+		upstreamEMA,
 		cacheReaperCalls,
 		droppedCacheUpdates,
 		droppedTelemetry,
@@ -223,6 +230,7 @@ func NewDNSMetrics(cache Cache, geoIpLookup geoblock.GeoIpLookup) (*DnsMetrics, 
 		TopBlockedDomains:   topBlockedDomains,
 		UpstreamTTLs:        upstreamTTLs,
 		UpstreamLatency:     upstreamLatency,
+		UpstreamEMA:         upstreamEMA,
 		CacheReaperCalls:    cacheReaperCalls,
 		DroppedCacheUpdates: droppedCacheUpdates,
 		DroppedTelemetry:    droppedTelemetry,

--- a/internal/metrics/request_snapshot.go
+++ b/internal/metrics/request_snapshot.go
@@ -71,8 +71,6 @@ func (t *RequestSnapshot) Forwarded() {
 	t.forwarded = true
 }
 
-// SetUpstream is no longer needed as latency is recorded directly by the client.
-
 func (t *RequestSnapshot) SetRcode(rcode string) {
 	t.rcode = rcode
 }

--- a/internal/metrics/request_snapshot.go
+++ b/internal/metrics/request_snapshot.go
@@ -22,8 +22,6 @@ type RequestSnapshot struct {
 	upstreamTTLs    []upstreamTTLInfo
 	errorCategory   string
 	forwarded       bool
-	upstream        string
-	upstreamLatency float64
 	requestLatency  float64
 	rcode           string
 }
@@ -73,10 +71,7 @@ func (t *RequestSnapshot) Forwarded() {
 	t.forwarded = true
 }
 
-func (t *RequestSnapshot) SetUpstream(upstream string, latency float64) {
-	t.upstream = upstream
-	t.upstreamLatency = latency
-}
+// SetUpstream is no longer needed as latency is recorded directly by the client.
 
 func (t *RequestSnapshot) SetRcode(rcode string) {
 	t.rcode = rcode
@@ -119,9 +114,6 @@ func (t *RequestSnapshot) Record(metrics *DnsMetrics) {
 	}
 	for _, upstreamTTL := range t.upstreamTTLs {
 		metrics.UpstreamTTLs.WithLabelValues(upstreamTTL.queryType).Observe(upstreamTTL.ttl)
-	}
-	if t.upstream != "" {
-		metrics.UpstreamLatency.WithLabelValues(t.upstream).Observe(t.upstreamLatency)
 	}
 	if t.rcode != "" {
 		metrics.ReplyCounts.WithLabelValues(t.rcode).Inc()

--- a/internal/metrics/request_snapshot.go
+++ b/internal/metrics/request_snapshot.go
@@ -13,17 +13,17 @@ type upstreamTTLInfo struct {
 }
 
 type RequestSnapshot struct {
-	source          string
-	ipAddr          string
-	startTime       time.Time
-	blockedDomains  []string
-	domains         []string
-	queryCounts     []queryCountInfo
-	upstreamTTLs    []upstreamTTLInfo
-	errorCategory   string
-	forwarded       bool
-	requestLatency  float64
-	rcode           string
+	source         string
+	ipAddr         string
+	startTime      time.Time
+	blockedDomains []string
+	domains        []string
+	queryCounts    []queryCountInfo
+	upstreamTTLs   []upstreamTTLInfo
+	errorCategory  string
+	forwarded      bool
+	requestLatency float64
+	rcode          string
 }
 
 func (t *RequestSnapshot) Finished() *RequestSnapshot {


### PR DESCRIPTION
Replaced the simple RoundRobin strategy with a latency-based selection
algorithm. Upstreams are now weighted by their moving-average response
times, with automatic penalties applied to failing servers to ensure
better load distribution and failover performance.

- Added EMA-based latency tracking per upstream.
- Moved latency measurement logic into the client layer.
- Updated documentation to reflect performance enhancements.