### PR TITLE
fix: optimize memory usage for blocklist loading

### DIFF
--- a/internal/app.go
+++ b/internal/app.go
@@ -161,15 +161,10 @@ func (app *App) RunServer(ctx context.Context) error {
 			return errors.Wrap(err, "failed to initialize GeoData database")
 		}
 	}
-	allHosts := make([]string, 0)
-	for _, url := range app.BlockListURLs {
-		hosts, err := blocklist.Fetch(url, app.Logger)
-		if err != nil {
-			return errors.Wrapf(err, "failed to download blocklist: %s", url)
-		}
-		allHosts = append(allHosts, hosts...)
+	blockList := blocklist.NewBlockList(nil, 0.0001, app.Logger)
+	if err := blocklist.LoadFromURLs(blockList, app.BlockListURLs); err != nil {
+		return errors.Wrap(err, "failed to load blocklists")
 	}
-	blockList := blocklist.NewBlockList(allHosts, 0.0001, app.Logger)
 	app.Logger.Info("Creating blocklist downloader cron job", "schedule", app.CronSchedule.Downloader)
 	blocklistUpdater := blocklist.NewBlocklistUpdater(blockList, app.BlockListURLs)
 	if _, err = crontab.AddJob(app.CronSchedule.Downloader, blocklistUpdater); err != nil {

--- a/internal/blocklist/blocklist.go
+++ b/internal/blocklist/blocklist.go
@@ -28,7 +28,9 @@ func NewBlockList(items []string, fpRate float64, logger *slog.Logger) *BlockLis
 		mutex:   &sync.RWMutex{},
 	}
 
-	blocklist.Load(items)
+	if items != nil {
+		blocklist.Load(items)
+	}
 
 	return blocklist
 }
@@ -68,6 +70,10 @@ func (blocklist *BlockList) Load(items []string) {
 		bf.AddString(item)
 	}
 
+	blocklist.ApplyBloomFilter(bf, n)
+}
+
+func (blocklist *BlockList) ApplyBloomFilter(bf *bloom.BloomFilter, n uint) {
 	m, k := bloom.EstimateParameters(n, blocklist.fpRate)
 	blocklist.logger.Info("Bloom filter created", "actual_fp_rate", bloom.EstimateFalsePositiveRate(m, k, n), "approx_size", bf.ApproximatedSize())
 

--- a/internal/blocklist/blocklist.go
+++ b/internal/blocklist/blocklist.go
@@ -28,10 +28,7 @@ func NewBlockList(items []string, fpRate float64, logger *slog.Logger) *BlockLis
 		mutex:   &sync.RWMutex{},
 	}
 
-	if items != nil {
-		blocklist.Load(items)
-	}
-
+	blocklist.Load(items)
 	return blocklist
 }
 

--- a/internal/blocklist/blocklist_test.go
+++ b/internal/blocklist/blocklist_test.go
@@ -22,10 +22,10 @@ func TestIsBlocked_ApexDomain_PublicSuffix(t *testing.T) {
 func TestNewBlockList_NilItems(t *testing.T) {
 	assert := assert.New(t)
 	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
-	
+
 	// This should not panic when IsBlocked is called
 	blockList := NewBlockList(nil, 0.0001, logger)
-	
+
 	assert.NotPanics(func() {
 		_, _ = blockList.IsBlocked("test.com")
 	})
@@ -34,9 +34,9 @@ func TestNewBlockList_NilItems(t *testing.T) {
 func TestNewBlockList_EmptyItems(t *testing.T) {
 	assert := assert.New(t)
 	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
-	
+
 	blockList := NewBlockList([]string{}, 0.0001, logger)
-	
+
 	assert.NotPanics(func() {
 		_, _ = blockList.IsBlocked("test.com")
 	})

--- a/internal/blocklist/blocklist_test.go
+++ b/internal/blocklist/blocklist_test.go
@@ -18,3 +18,26 @@ func TestIsBlocked_ApexDomain_PublicSuffix(t *testing.T) {
 	assert.NoError(err)
 	assert.False(isBlocked)
 }
+
+func TestNewBlockList_NilItems(t *testing.T) {
+	assert := assert.New(t)
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	
+	// This should not panic when IsBlocked is called
+	blockList := NewBlockList(nil, 0.0001, logger)
+	
+	assert.NotPanics(func() {
+		_, _ = blockList.IsBlocked("test.com")
+	})
+}
+
+func TestNewBlockList_EmptyItems(t *testing.T) {
+	assert := assert.New(t)
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	
+	blockList := NewBlockList([]string{}, 0.0001, logger)
+	
+	assert.NotPanics(func() {
+		_, _ = blockList.IsBlocked("test.com")
+	})
+}

--- a/internal/blocklist/update.go
+++ b/internal/blocklist/update.go
@@ -40,14 +40,6 @@ func LoadFromURLs(bl *BlockList, urls []string) error {
 	}
 	files := make([]downloadedFile, 0, len(urls))
 
-	for _, url := range urls {
-		path, _, isTemp, err := downloader.Download(bl.logger, "", "blocklist", url, "")
-		if err != nil {
-			return errors.Wrapf(err, "failed to download blocklist for counting: %s", url)
-		}
-		files = append(files, downloadedFile{path: path, url: url, isTemp: isTemp})
-	}
-
 	defer func() {
 		for _, f := range files {
 			if f.isTemp {
@@ -55,6 +47,14 @@ func LoadFromURLs(bl *BlockList, urls []string) error {
 			}
 		}
 	}()
+
+	for _, url := range urls {
+		path, _, isTemp, err := downloader.Download(bl.logger, "", "blocklist", url, "")
+		if err != nil {
+			return errors.Wrapf(err, "failed to download blocklist for counting: %s", url)
+		}
+		files = append(files, downloadedFile{path: path, url: url, isTemp: isTemp})
+	}
 
 	var totalCount uint
 	for _, f := range files {

--- a/internal/blocklist/update.go
+++ b/internal/blocklist/update.go
@@ -121,7 +121,7 @@ func countFromFile(path string, logger *slog.Logger) (int, error) {
 	if err != nil {
 		return 0, errors.Wrap(err, "failed to open blocklist file for counting")
 	}
-	defer file.Close()
+	defer func() { _ = file.Close() }()
 	err = scanBlocklist(file, logger, func(_ string) {
 		count++
 	})
@@ -133,7 +133,7 @@ func streamFromFile(path string, logger *slog.Logger, handler func(string)) erro
 	if err != nil {
 		return errors.Wrap(err, "failed to open blocklist file for streaming")
 	}
-	defer file.Close()
+	defer func() { _ = file.Close() }()
 	return scanBlocklist(file, logger, handler)
 }
 

--- a/internal/blocklist/update.go
+++ b/internal/blocklist/update.go
@@ -65,6 +65,11 @@ func LoadFromURLs(bl *BlockList, urls []string) error {
 		totalCount += uint(count)
 	}
 
+	// Avoid creating a bloom filter with 0 items, which will panic
+	if totalCount == 0 {
+		totalCount = 1
+	}
+
 	bf := bloom.NewWithEstimates(totalCount, bl.fpRate)
 	for _, f := range files {
 		if err := streamFromFile(f.path, bl.logger, func(host string) {

--- a/internal/blocklist/update.go
+++ b/internal/blocklist/update.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"strings"
 
+	"github.com/bits-and-blooms/bloom/v3"
 	"github.com/cockroachdb/errors"
 	"github.com/rm-hull/dot-block/internal/downloader"
 )
@@ -26,57 +27,113 @@ func NewBlocklistUpdater(blocklist *BlockList, urls []string) *BlocklistUpdater 
 }
 
 func (job *BlocklistUpdater) Run() {
-	allHosts := make([]string, 0)
-	for _, url := range job.URLs {
-		hosts, err := Fetch(url, job.Blocklist.logger)
-		if err != nil {
-			job.Blocklist.logger.Error("failed to download blocklist for cron reload", "error", err, "url", url)
-			return
-		}
-
-		allHosts = append(allHosts, hosts...)
+	if err := LoadFromURLs(job.Blocklist, job.URLs); err != nil {
+		job.Blocklist.logger.Error("failed to download blocklist for cron reload", "error", err)
 	}
-	job.Blocklist.Load(allHosts)
+}
+
+func LoadFromURLs(bl *BlockList, urls []string) error {
+	type downloadedFile struct {
+		path   string
+		url    string
+		isTemp bool
+	}
+	files := make([]downloadedFile, 0, len(urls))
+
+	for _, url := range urls {
+		path, _, isTemp, err := downloader.Download(bl.logger, "", "blocklist", url, "")
+		if err != nil {
+			return errors.Wrapf(err, "failed to download blocklist for counting: %s", url)
+		}
+		files = append(files, downloadedFile{path: path, url: url, isTemp: isTemp})
+	}
+
+	defer func() {
+		for _, f := range files {
+			if f.isTemp {
+				_ = os.Remove(f.path)
+			}
+		}
+	}()
+
+	var totalCount uint
+	for _, f := range files {
+		count, err := countFromFile(f.path, bl.logger)
+		if err != nil {
+			return errors.Wrapf(err, "failed to count hosts in file %s (url: %s)", f.path, f.url)
+		}
+		totalCount += uint(count)
+	}
+
+	bf := bloom.NewWithEstimates(totalCount, bl.fpRate)
+	for _, f := range files {
+		if err := streamFromFile(f.path, bl.logger, func(host string) {
+			bf.AddString(host)
+		}); err != nil {
+			return errors.Wrapf(err, "failed to stream hosts from file %s (url: %s)", f.path, f.url)
+		}
+	}
+
+	bl.ApplyBloomFilter(bf, totalCount)
+	return nil
 }
 
 func Fetch(url string, logger *slog.Logger) ([]string, error) {
 	blocklist := make([]string, 0, 100_000)
-	err := downloader.TransientDownload(logger, "", "blocklist", url, "", func(tmpFile string, header http.Header) error {
-		file, err := os.Open(tmpFile)
-		if err != nil {
-			return errors.Wrap(err, "failed to open downloaded blocklist")
-		}
-
-		defer func() {
-			if err := file.Close(); err != nil {
-				logger.Warn("error closing blocklist file", "error", err)
-			}
-		}()
-
-		scanner := bufio.NewScanner(file)
-		for scanner.Scan() {
-			line := scanner.Text()
-			if strings.HasPrefix(line, "# ") {
-				logger.Info("Blocklist", "comment", line)
-			} else if len(strings.Trim(line, "# ")) == 0 || strings.HasPrefix(line, "## ") {
-				continue
-			} else {
-				for _, prefix := range prefixes {
-					if after, ok := strings.CutPrefix(line, prefix); ok {
-						line = after
-					}
-				}
-				blocklist = append(blocklist, line)
-			}
-		}
-
-		if err := scanner.Err(); err != nil {
-			return errors.Wrap(err, "error reading response body")
-		}
-
-		return nil
+	err := streamHosts(url, logger, func(host string) {
+		blocklist = append(blocklist, host)
 	})
 
-	logger.Info("Blocklist loaded successfully", "count", len(blocklist))
+	if err == nil {
+		logger.Info("Blocklist loaded successfully", "count", len(blocklist))
+	}
 	return blocklist, err
+}
+
+func scanBlocklist(file *os.File, logger *slog.Logger, handler func(string)) error {
+	scanner := bufio.NewScanner(file)
+	for scanner.Scan() {
+		line := scanner.Text()
+		if strings.HasPrefix(line, "# ") {
+			logger.Info("Blocklist", "comment", line)
+		} else if len(strings.Trim(line, "# ")) == 0 || strings.HasPrefix(line, "## ") {
+			continue
+		} else {
+			for _, prefix := range prefixes {
+				if after, ok := strings.CutPrefix(line, prefix); ok {
+					line = after
+				}
+			}
+			handler(line)
+		}
+	}
+	return scanner.Err()
+}
+
+func countFromFile(path string, logger *slog.Logger) (int, error) {
+	count := 0
+	file, err := os.Open(path)
+	if err != nil {
+		return 0, errors.Wrap(err, "failed to open blocklist file for counting")
+	}
+	defer file.Close()
+	err = scanBlocklist(file, logger, func(_ string) {
+		count++
+	})
+	return count, err
+}
+
+func streamFromFile(path string, logger *slog.Logger, handler func(string)) error {
+	file, err := os.Open(path)
+	if err != nil {
+		return errors.Wrap(err, "failed to open blocklist file for streaming")
+	}
+	defer file.Close()
+	return scanBlocklist(file, logger, handler)
+}
+
+func streamHosts(url string, logger *slog.Logger, handler func(string)) error {
+	return downloader.TransientDownload(logger, "", "blocklist-stream", url, "", func(tmpFile string, header http.Header) error {
+		return streamFromFile(tmpFile, logger, handler)
+	})
 }

--- a/internal/blocklist/update.go
+++ b/internal/blocklist/update.go
@@ -93,11 +93,11 @@ func Fetch(url string, logger *slog.Logger) ([]string, error) {
 func scanBlocklist(file *os.File, logger *slog.Logger, handler func(string)) error {
 	scanner := bufio.NewScanner(file)
 	for scanner.Scan() {
-		line := scanner.Text()
+		line := strings.TrimSpace(scanner.Text())
 		if strings.HasPrefix(line, "# ") {
 			logger.Info("Blocklist", "comment", line)
 		} else if len(strings.Trim(line, "# ")) == 0 || strings.HasPrefix(line, "## ") {
-			continue
+			continue // ignore double-octothorpe and empty comments
 		} else {
 			for _, prefix := range prefixes {
 				if after, ok := strings.CutPrefix(line, prefix); ok {

--- a/internal/downloader/download.go
+++ b/internal/downloader/download.go
@@ -32,13 +32,13 @@ func isValidUrl(uri string) bool {
 	return err == nil && (u.Scheme == "http" || u.Scheme == "https" || u.Scheme == "file")
 }
 
-func TransientDownload(logger *slog.Logger, dataDir, purpose, uri, redact string, handler func(tmpfile string, header http.Header) error) error {
+func Download(logger *slog.Logger, dataDir, purpose, uri, redact string) (string, http.Header, bool, error) {
 	if path, ok := isValidFile(uri); ok {
-		return handler(path, http.Header{})
+		return path, http.Header{}, false, nil
 	}
 
 	if !isValidUrl(uri) {
-		return handler(uri, http.Header{})
+		return "", nil, false, fmt.Errorf("invalid URL: %s", uri)
 	}
 
 	redactedUri := uri
@@ -48,14 +48,14 @@ func TransientDownload(logger *slog.Logger, dataDir, purpose, uri, redact string
 	logger.Info("Retrieving file", "purpose", purpose, "uri", redactedUri)
 	req, err := http.NewRequest("GET", uri, nil)
 	if err != nil {
-		return errors.Wrapf(err, "failed to create request")
+		return "", nil, false, errors.Wrapf(err, "failed to create request")
 	}
 
 	req.Header.Add("User-Agent", "dot-block downloader (https://github.com/rm-hull/dot-block)")
 	client := &http.Client{Timeout: 5 * time.Minute}
 	resp, err := client.Do(req)
 	if err != nil {
-		return errors.Wrapf(err, "failed to fetch from %s", redactedUri)
+		return "", nil, false, errors.Wrapf(err, "failed to fetch from %s", redactedUri)
 	}
 
 	defer func() {
@@ -65,12 +65,12 @@ func TransientDownload(logger *slog.Logger, dataDir, purpose, uri, redact string
 	}()
 
 	if resp.StatusCode > 299 {
-		return fmt.Errorf("error response from %s: %s", redactedUri, resp.Status)
+		return "", nil, false, fmt.Errorf("error response from %s: %s", redactedUri, resp.Status)
 	}
 
 	tmp, err := os.CreateTemp(dataDir, fmt.Sprintf("dot-block-%s-download-*", purpose))
 	if err != nil {
-		return err
+		return "", nil, false, err
 	}
 	tmpfile := tmp.Name()
 
@@ -86,20 +86,31 @@ func TransientDownload(logger *slog.Logger, dataDir, purpose, uri, redact string
 	}
 	logger.Info(fmt.Sprintf("Downloading content (%s) to %s", filesize, tmpfile))
 
-	defer func() {
-		logger.Info(fmt.Sprintf("Removing temporary file: %s", tmpfile))
-		if err := os.Remove(tmpfile); err != nil {
-			logger.Info(fmt.Sprintf("failed to remove file %s: %v", tmpfile, err))
-		}
-	}()
-
 	if _, err := io.Copy(tmp, resp.Body); err != nil {
 		_ = tmp.Close()
-		return errors.Wrapf(err, "failed to copy response body")
+		return "", nil, false, errors.Wrapf(err, "failed to copy response body")
 	}
 
 	if err := tmp.Close(); err != nil {
-		return errors.Wrapf(err, "failed to close temporary file")
+		return "", nil, false, errors.Wrapf(err, "failed to close temporary file")
 	}
-	return handler(tmpfile, resp.Header)
+	return tmpfile, resp.Header, true, nil
+}
+
+func TransientDownload(logger *slog.Logger, dataDir, purpose, uri, redact string, handler func(tmpfile string, header http.Header) error) error {
+	tmpfile, header, isTemp, err := Download(logger, dataDir, purpose, uri, redact)
+	if err != nil {
+		return err
+	}
+
+	defer func() {
+		if isTemp {
+			logger.Info(fmt.Sprintf("Removing temporary file: %s", tmpfile))
+			if err := os.Remove(tmpfile); err != nil {
+				logger.Info(fmt.Sprintf("failed to remove file %s: %v", tmpfile, err))
+			}
+		}
+	}()
+
+	return handler(tmpfile, header)
 }


### PR DESCRIPTION
Refactored blocklist loading to stream files from disk, significantly reducing memory overhead by calculating exact Bloom filter size before allocation.

```mermaid
sequenceDiagram
    participant App
    participant Downloader
    participant FileSystem
    participant BloomFilter

    App->>Downloader: Download blocklists
    Downloader-->>FileSystem: Store temp files
    App->>FileSystem: Count entries in files
    FileSystem-->>App: Total count
    App->>BloomFilter: Initialize with size (totalCount)
    App->>FileSystem: Stream files
    FileSystem-->>BloomFilter: Add entries to filter
    App->>FileSystem: Cleanup temp files
```