### PR TITLE
feat: add real-time DNS request streaming via SSE

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -13,7 +13,8 @@
             "args": [
                 "--dev-mode",
                 "--http-port=8080",
-                "--allowed-hosts=localhost"
+                "--allowed-hosts=localhost",
+                "--log-level=debug"
             ]
         }
     ]

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ DoT Block is a high-performance, caching, and filtering DNS-over-TLS (DoT) serve
 -   **Easy to Deploy:** Can be run as a standalone binary or as a Docker container.
 -   **Automatic TLS:** Uses Let's Encrypt to automatically obtain and renew TLS certificates.
 -   **Advanced Observability:** Exports detailed Prometheus metrics including upstream health, failure reasons, and cache effectiveness.
+-   **Real-time Request Streaming:** An admin-only SSE endpoint streams live DNS requests, including client IP, location data (ASN/Country), and blocking status.
 -   **Latency-Aware Routing:** Automatically prefers the fastest upstream resolvers based on real-time response latency and applies penalties to failing servers to ensure high availability.
 -   **Hardened TLS:** Uses a strict TLS configuration (TLS 1.2+) with forward-secrecy prioritized cipher suites to ensure maximum security for DoT connections.
 -   **Distributed Tracing:** Integrates with OpenTelemetry (OTel), providing end-to-end traces of DNS requests and correlating them with logs via `trace_id` and `span_id`.
@@ -143,12 +144,30 @@ openssl s_client -connect dot.your-domain.com:853 -alpn dot -servername dot.your
 
 The server provides several HTTP endpoints for monitoring and management on the configured `--http-port` (default 80).
 
+#### Public endpoints
+
 - `GET /metrics`: Exports Prometheus metrics.
-- `GET /reload`: Triggers an asynchronous reload of the blocklists.
-- `POST /check`: Checks whether provided domains are blocked. Accepts a JSON array of strings or a newline-separated list of domains in the request body.
+- `GET /healthz`: Simple heathcheck.
 - `GET /dns-query` and `POST /dns-query`: DNS-over-HTTPS (DoH) endpoint. `GET /dns-query` expects a `dns` query parameter containing the base64url-encoded DNS wire message. `POST /dns-query` expects the raw DNS wire format in the request body. Responses are returned with content type `application/dns-message`.
 
-If `--metrics-auth` is configured, `/metrics` and `/reload` are protected by basic authentication.
+If `--metrics-auth` is configured, the `/metrics` endpoint is protected by basic authentication.
+
+#### Admin endpoints
+
+While the public endpoints are available on the main domain, the management APIs are hosted on the admin subdomain (e.g., `admin.dot.your-domain.com`):
+
+- `POST /api/reload`: Triggers an asynchronous reload of the blocklists.
+- `POST /api/check`: Checks whether provided domains are blocked. Accepts a JSON array of strings or a newline-separated list of domains in the request body.
+- `GET /api/whoami`: Returns information about the currently authenticated user.
+- `GET /api/events`: Streams live DNS requests via Server-Sent Events (SSE). Each event is a JSON object containing the queried domain, client IP, source (UDP/TCP/DoT/DoH), whether it was blocked, and GeoIP data (ASN and Country ISO code).
+
+### Testing the Event Stream
+
+You can stream live DNS requests using `curl`:
+
+```bash
+curl -N -H "Accept: text/event-stream" http://admin.localhost:8080/api/events
+```
 
 ### iOS / iPadOS Configuration
 

--- a/internal/app.go
+++ b/internal/app.go
@@ -31,6 +31,7 @@ import (
 	"github.com/rm-hull/dot-block/internal/http/handlers"
 	"github.com/rm-hull/dot-block/internal/http/middlewares"
 	"github.com/rm-hull/dot-block/internal/http/routes"
+	"github.com/rm-hull/dot-block/internal/http/sse"
 	"github.com/rm-hull/dot-block/internal/logging"
 	"github.com/rm-hull/dot-block/internal/metrics"
 	"github.com/rm-hull/dot-block/internal/noisefilter"
@@ -222,7 +223,8 @@ func (app *App) RunServer(ctx context.Context) error {
 		return errors.Wrap(err, "failed to initialize upstream DNS client")
 	}
 
-	dispatcher, err := forwarder.NewDNSDispatcher(cache, metrics, dnsClient, blockList, noiseFilter, app.CacheTtlFloor, app.Logger, app.EnableECS)
+	broadcaster := sse.NewBroadcaster(app.Logger)
+	dispatcher, err := forwarder.NewDNSDispatcher(cache, metrics, dnsClient, blockList, noiseFilter, geoIpLookup, broadcaster, app.CacheTtlFloor, app.Logger, app.EnableECS)
 	if err != nil {
 		return errors.Wrap(err, "failed to create dispatcher")
 	}
@@ -411,7 +413,8 @@ func (app *App) startHttpServer(dnsClient *forwarder.RoundRobinClient, blocklist
 
 	routes.NewAdminGroup(r, "admin."+serverName, app.DevMode,
 		blocklistHandler.Check,
-		blocklistHandler.Reload)
+		blocklistHandler.Reload,
+		dispatcher.GetBroadcaster())
 
 	return r, nil
 }

--- a/internal/forwarder/dispatcher.go
+++ b/internal/forwarder/dispatcher.go
@@ -2,6 +2,7 @@ package forwarder
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"log/slog"
 	"net"
@@ -11,6 +12,8 @@ import (
 	"github.com/cockroachdb/errors"
 	"github.com/miekg/dns"
 	"github.com/rm-hull/dot-block/internal/blocklist"
+	"github.com/rm-hull/dot-block/internal/geoblock"
+	"github.com/rm-hull/dot-block/internal/http/sse"
 	"github.com/rm-hull/dot-block/internal/metrics"
 	"github.com/rm-hull/dot-block/internal/noisefilter"
 	"github.com/rm-hull/dot-block/internal/telemetry"
@@ -57,6 +60,8 @@ type DNSDispatcher struct {
 	metrics     *metrics.DnsMetrics
 	logger      *slog.Logger
 	noiseFilter *noisefilter.NoiseFilter
+	geoIp       geoblock.GeoIpLookup
+	broadcaster *sse.Broadcaster
 	enableECS   bool
 	snapshotCh  chan *metrics.RequestSnapshot
 	done        chan struct{}
@@ -68,6 +73,8 @@ func NewDNSDispatcher(
 	dnsClient *RoundRobinClient,
 	blockList *blocklist.BlockList,
 	noiseFilter *noisefilter.NoiseFilter,
+	geoIp geoblock.GeoIpLookup,
+	broadcaster *sse.Broadcaster,
 	ttlFloor time.Duration,
 	logger *slog.Logger,
 	enableECS bool,
@@ -86,6 +93,8 @@ func NewDNSDispatcher(
 		metrics:     dnsMetrics,
 		logger:      logger,
 		noiseFilter: noiseFilter,
+		geoIp:       geoIp,
+		broadcaster: broadcaster,
 		enableECS:   enableECS,
 		snapshotCh:  make(chan *metrics.RequestSnapshot, SNAPSHOT_BUFFER_SIZE),
 		done:        make(chan struct{}),
@@ -102,6 +111,10 @@ func NewDNSDispatcher(
 func (d *DNSDispatcher) Close() {
 	d.cache.Close()
 	close(d.done)
+}
+
+func (d *DNSDispatcher) GetBroadcaster() *sse.Broadcaster {
+	return d.broadcaster
 }
 
 func (d *DNSDispatcher) HandleDNSRequest(source DNSSource) DispatcherFunc {
@@ -140,6 +153,9 @@ func (d *DNSDispatcher) HandleDNSRequest(source DNSSource) DispatcherFunc {
 			snapshot: metrics.NewRequestSnapshot(time.Now(), string(source), ipAddr),
 			ipAddr:   ipAddr,
 			subnet:   d.computeSubnet(ipAddr),
+		}
+		if len(req.Question) > 0 {
+			requestCtx.snapshot.SetPrimaryDomain(req.Question[0].Name)
 		}
 
 		defer func() {
@@ -205,6 +221,29 @@ func (d *DNSDispatcher) snapshotWorker() {
 				return
 			}
 			snapshot.Record(d.metrics)
+
+			// Broadcast event in the background
+			if d.broadcaster != nil {
+				event := sse.Event{
+					Domain:   snapshot.PrimaryDomain(),
+					ClientIP: snapshot.IPAddr(),
+					Source:   snapshot.Source(),
+					Blocked:  snapshot.IsBlocked(),
+					Time:     time.Now().Format(time.RFC3339),
+				}
+
+				if d.geoIp != nil && snapshot.IPAddr() != "unknown" {
+					if geodata, err := d.geoIp.GetAll(snapshot.IPAddr()); err == nil {
+						event.Country = geodata.ISOCode
+						if geodata.ASN != "" && geodata.Provider != "" {
+							event.ASN = geodata.ASN + ":" + geodata.Provider
+						}
+					}
+				}
+
+				msg, _ := json.Marshal(event)
+				d.broadcaster.Broadcast(msg)
+			}
 		case <-d.done:
 			return
 		}

--- a/internal/forwarder/dispatcher.go
+++ b/internal/forwarder/dispatcher.go
@@ -233,7 +233,7 @@ func (d *DNSDispatcher) snapshotWorker() {
 				}
 
 				if d.geoIp != nil && snapshot.IPAddr() != "unknown" {
-					if geodata, err := d.geoIp.GetAll(snapshot.IPAddr()); err == nil {
+					if geodata, err := d.geoIp.GetAll(snapshot.IPAddr()); err == nil && geodata != nil {
 						event.Country = geodata.ISOCode
 						if geodata.ASN != "" && geodata.Provider != "" {
 							event.ASN = geodata.ASN + ":" + geodata.Provider

--- a/internal/forwarder/dispatcher_test.go
+++ b/internal/forwarder/dispatcher_test.go
@@ -96,7 +96,7 @@ func setupDispatcherTest(t *testing.T, upstream string, logger *slog.Logger, ena
 	dnsClient, err := NewRoundRobinClient(metrics, 2*time.Second, 2*time.Second, 2*time.Second, logger, upstream)
 	require.NoError(t, err)
 
-	dispatcher, err := NewDNSDispatcher(cache, metrics, dnsClient, blockList, noisefilter.NewNoiseFilter(), mockGeo, sse.NewBroadcaster(), 1*time.Minute, logger, enableECS)
+	dispatcher, err := NewDNSDispatcher(cache, metrics, dnsClient, blockList, noisefilter.NewNoiseFilter(), mockGeo, sse.NewBroadcaster(logger), 1*time.Minute, logger, enableECS)
 	require.NoError(t, err)
 	t.Cleanup(dispatcher.Close)
 
@@ -388,7 +388,7 @@ func TestDNSDispatcher_NegativeCacheTtlFloor(t *testing.T) {
 	dnsClient, err := NewRoundRobinClient(metrics, 2*time.Second, 2*time.Second, 2*time.Second, logger, "8.8.8.8:53")
 	assert.NoError(t, err)
 
-	dispatcher, err := NewDNSDispatcher(cache, metrics, dnsClient, blockList, noisefilter.NewNoiseFilter(), mockGeo, sse.NewBroadcaster(), -1*time.Second, logger, false)
+	dispatcher, err := NewDNSDispatcher(cache, metrics, dnsClient, blockList, noisefilter.NewNoiseFilter(), mockGeo, sse.NewBroadcaster(logger), -1*time.Second, logger, false)
 	assert.Error(t, err)
 	assert.Nil(t, dispatcher)
 	assert.Contains(t, err.Error(), "TTL floor cannot be negative")
@@ -714,7 +714,7 @@ func TestDNSDispatcher_ECS_Injection(t *testing.T) {
 			metrics, _ := metrics.NewDNSMetrics(cache, mockGeo)
 			dnsClient, _ := NewRoundRobinClient(metrics, 2*time.Second, 2*time.Second, 2*time.Second, logger, upstream)
 
-			dispatcher, _ := NewDNSDispatcher(cache, metrics, dnsClient, blockList, noisefilter.NewNoiseFilter(), mockGeo, sse.NewBroadcaster(), 1*time.Minute, logger, tt.enableECS)
+			dispatcher, _ := NewDNSDispatcher(cache, metrics, dnsClient, blockList, noisefilter.NewNoiseFilter(), mockGeo, sse.NewBroadcaster(logger), 1*time.Minute, logger, tt.enableECS)
 			defer dispatcher.Close()
 
 			// Mock ResponseWriter with the specific client IP

--- a/internal/forwarder/dispatcher_test.go
+++ b/internal/forwarder/dispatcher_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/miekg/dns"
 	"github.com/rm-hull/dot-block/internal/blocklist"
 	"github.com/rm-hull/dot-block/internal/geoblock"
+	"github.com/rm-hull/dot-block/internal/http/sse"
 	"github.com/rm-hull/dot-block/internal/metrics"
 	"github.com/rm-hull/dot-block/internal/noisefilter"
 	"github.com/stretchr/testify/assert"
@@ -95,7 +96,7 @@ func setupDispatcherTest(t *testing.T, upstream string, logger *slog.Logger, ena
 	dnsClient, err := NewRoundRobinClient(metrics, 2*time.Second, 2*time.Second, 2*time.Second, logger, upstream)
 	require.NoError(t, err)
 
-	dispatcher, err := NewDNSDispatcher(cache, metrics, dnsClient, blockList, noisefilter.NewNoiseFilter(), 1*time.Minute, logger, enableECS)
+	dispatcher, err := NewDNSDispatcher(cache, metrics, dnsClient, blockList, noisefilter.NewNoiseFilter(), mockGeo, sse.NewBroadcaster(), 1*time.Minute, logger, enableECS)
 	require.NoError(t, err)
 	t.Cleanup(dispatcher.Close)
 
@@ -387,7 +388,7 @@ func TestDNSDispatcher_NegativeCacheTtlFloor(t *testing.T) {
 	dnsClient, err := NewRoundRobinClient(metrics, 2*time.Second, 2*time.Second, 2*time.Second, logger, "8.8.8.8:53")
 	assert.NoError(t, err)
 
-	dispatcher, err := NewDNSDispatcher(cache, metrics, dnsClient, blockList, noisefilter.NewNoiseFilter(), -1*time.Second, logger, false)
+	dispatcher, err := NewDNSDispatcher(cache, metrics, dnsClient, blockList, noisefilter.NewNoiseFilter(), mockGeo, sse.NewBroadcaster(), -1*time.Second, logger, false)
 	assert.Error(t, err)
 	assert.Nil(t, dispatcher)
 	assert.Contains(t, err.Error(), "TTL floor cannot be negative")
@@ -713,7 +714,7 @@ func TestDNSDispatcher_ECS_Injection(t *testing.T) {
 			metrics, _ := metrics.NewDNSMetrics(cache, mockGeo)
 			dnsClient, _ := NewRoundRobinClient(metrics, 2*time.Second, 2*time.Second, 2*time.Second, logger, upstream)
 
-			dispatcher, _ := NewDNSDispatcher(cache, metrics, dnsClient, blockList, noisefilter.NewNoiseFilter(), 1*time.Minute, logger, tt.enableECS)
+			dispatcher, _ := NewDNSDispatcher(cache, metrics, dnsClient, blockList, noisefilter.NewNoiseFilter(), mockGeo, sse.NewBroadcaster(), 1*time.Minute, logger, tt.enableECS)
 			defer dispatcher.Close()
 
 			// Mock ResponseWriter with the specific client IP

--- a/internal/http/routes/routes.go
+++ b/internal/http/routes/routes.go
@@ -8,6 +8,7 @@ import (
 	"github.com/gin-gonic/gin"
 	"github.com/rm-hull/dot-block/internal/http/handlers"
 	"github.com/rm-hull/dot-block/internal/http/middlewares"
+	"github.com/rm-hull/dot-block/internal/http/sse"
 	"github.com/rm-hull/dot-block/internal/http/web"
 )
 
@@ -23,7 +24,7 @@ func NewPublicGroup(r *gin.Engine, publicHost string, mobileConfigHandler gin.Ha
 	return public
 }
 
-func NewAdminGroup(r *gin.Engine, adminHost string, devMode bool, blocklistCheckHandler gin.HandlerFunc, blocklistReloadHandler gin.HandlerFunc) *gin.RouterGroup {
+func NewAdminGroup(r *gin.Engine, adminHost string, devMode bool, blocklistCheckHandler gin.HandlerFunc, blocklistReloadHandler gin.HandlerFunc, broadcaster *sse.Broadcaster) *gin.RouterGroup {
 
 	// --- Admin: SPA + API, pinned to the admin host, auth on top ---
 	admin := r.Group("/")
@@ -34,6 +35,24 @@ func NewAdminGroup(r *gin.Engine, adminHost string, devMode bool, blocklistCheck
 		{
 			api.POST("/check", blocklistCheckHandler)
 			api.POST("/reload", blocklistReloadHandler)
+			api.GET("/events", func(c *gin.Context) {
+				subscriber := broadcaster.Subscribe()
+				defer broadcaster.Unsubscribe(subscriber)
+
+				c.Header("Content-Type", "text/event-stream")
+				c.Header("Cache-Control", "no-cache")
+				c.Header("Connection", "keep-alive")
+
+				for {
+					select {
+					case msg := <-subscriber:
+						c.SSEvent("message", string(msg))
+						c.Writer.Flush()
+					case <-c.Request.Context().Done():
+						return
+					}
+				}
+			})
 			api.GET("/whoami", func(c *gin.Context) {
 				user, _ := c.Get("user")
 				email, _ := c.Get("email")

--- a/internal/http/routes/routes.go
+++ b/internal/http/routes/routes.go
@@ -49,7 +49,10 @@ func NewAdminGroup(r *gin.Engine, adminHost string, devMode bool, blocklistCheck
 
 				for {
 					select {
-					case msg := <-subscriber:
+					case msg, ok := <-subscriber:
+						if !ok {
+							return
+						}
 						c.SSEvent("message", string(msg))
 						c.Writer.Flush()
 					case <-c.Request.Context().Done():

--- a/internal/http/routes/routes.go
+++ b/internal/http/routes/routes.go
@@ -36,6 +36,10 @@ func NewAdminGroup(r *gin.Engine, adminHost string, devMode bool, blocklistCheck
 			api.POST("/check", blocklistCheckHandler)
 			api.POST("/reload", blocklistReloadHandler)
 			api.GET("/events", func(c *gin.Context) {
+				if broadcaster == nil {
+					c.AbortWithStatus(http.StatusServiceUnavailable)
+					return
+				}
 				subscriber := broadcaster.Subscribe()
 				defer broadcaster.Unsubscribe(subscriber)
 

--- a/internal/http/sse/broadcaster.go
+++ b/internal/http/sse/broadcaster.go
@@ -1,0 +1,63 @@
+package sse
+
+import (
+	"log/slog"
+	"sync"
+)
+
+type Event struct {
+	Domain   string `json:"domain"`
+	ClientIP string `json:"client_ip"`
+	Source   string `json:"source"`
+	Blocked  bool   `json:"blocked"`
+	ASN      string `json:"asn,omitempty"`
+	Country  string `json:"country,omitempty"`
+	Time     string `json:"time"`
+}
+
+type Broadcaster struct {
+	subscribers map[chan []byte]struct{}
+	logger      *slog.Logger
+	mu          sync.RWMutex
+}
+
+func NewBroadcaster(logger *slog.Logger) *Broadcaster {
+	return &Broadcaster{
+		subscribers: make(map[chan []byte]struct{}),
+		logger:      logger,
+	}
+}
+
+func (b *Broadcaster) Subscribe() chan []byte {
+	b.logger.Debug("New subscriber added")
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	ch := make(chan []byte, 10)
+	b.subscribers[ch] = struct{}{}
+	return ch
+}
+
+func (b *Broadcaster) Unsubscribe(ch chan []byte) {
+	b.logger.Debug("Subscriber removed")
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	if _, ok := b.subscribers[ch]; ok {
+		delete(b.subscribers, ch)
+		close(ch)
+	}
+}
+
+func (b *Broadcaster) Broadcast(msg []byte) {
+	b.mu.RLock()
+	defer b.mu.RUnlock()
+
+	for ch := range b.subscribers {
+		select {
+		case ch <- msg:
+		default:
+			// Buffer full, drop message for this slow client
+		}
+	}
+}

--- a/internal/http/sse/broadcaster_test.go
+++ b/internal/http/sse/broadcaster_test.go
@@ -1,0 +1,28 @@
+package sse
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestBroadcaster(t *testing.T) {
+	b := NewBroadcaster()
+
+	// Register a subscriber
+	subscriber := b.Subscribe()
+	defer b.Unsubscribe(subscriber)
+
+	// Broadcast a message
+	msg := []byte("hello")
+	b.Broadcast(msg)
+
+	// Verify receipt
+	select {
+	case received := <-subscriber:
+		assert.Equal(t, msg, received)
+	case <-time.After(100 * time.Millisecond):
+		t.Fatal("timed out waiting for message")
+	}
+}

--- a/internal/http/sse/broadcaster_test.go
+++ b/internal/http/sse/broadcaster_test.go
@@ -1,6 +1,8 @@
 package sse
 
 import (
+	"io"
+	"log/slog"
 	"testing"
 	"time"
 
@@ -8,7 +10,8 @@ import (
 )
 
 func TestBroadcaster(t *testing.T) {
-	b := NewBroadcaster()
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	b := NewBroadcaster(logger)
 
 	// Register a subscriber
 	subscriber := b.Subscribe()

--- a/internal/metrics/request_snapshot.go
+++ b/internal/metrics/request_snapshot.go
@@ -19,6 +19,7 @@ type RequestSnapshot struct {
 	source         string
 	ipAddr         string
 	startTime      time.Time
+	primaryDomain  string
 	blockedDomains []string
 	domains        []string
 	queryCounts    []queryCountInfo
@@ -32,6 +33,18 @@ type RequestSnapshot struct {
 func (t *RequestSnapshot) Finished() *RequestSnapshot {
 	t.requestLatency = t.Latency().Seconds()
 	return t
+}
+
+func (t *RequestSnapshot) IPAddr() string {
+	return t.ipAddr
+}
+
+func (t *RequestSnapshot) Source() string {
+	return t.source
+}
+
+func (t *RequestSnapshot) IsBlocked() bool {
+	return len(t.blockedDomains) > 0
 }
 
 func (t *RequestSnapshot) Latency() time.Duration {
@@ -48,6 +61,14 @@ func NewRequestSnapshot(startTime time.Time, source string, ipAddr string) *Requ
 		queryCounts:    []queryCountInfo{},
 		upstreamTTLs:   []upstreamTTLInfo{},
 	}
+}
+
+func (t *RequestSnapshot) SetPrimaryDomain(domain string) {
+	t.primaryDomain = domain
+}
+
+func (t *RequestSnapshot) PrimaryDomain() string {
+	return t.primaryDomain
 }
 
 func (t *RequestSnapshot) AddBlockedDomain(domain string) {

--- a/test.http
+++ b/test.http
@@ -56,3 +56,8 @@ Accept: text/html
 ### Who Am I
 GET http://admin.localhost:8080/api/whoami
 Accept: application/json
+
+
+### DNS Events Stream (SSE)
+GET http://admin.localhost:8080/api/events
+Accept: text/event-stream


### PR DESCRIPTION
Introduced an administrative `/api/events` endpoint that streams live DNS
request data—including domain, client IP, source, blocking status, and GeoIP info—using Server-Sent Events (SSE).

```mermaid
sequenceDiagram
    participant C as DNS Client
    participant D as Dispatcher
    participant B as Broadcaster
    participant A as Admin API (/api/events)

    C->>D: DNS Request
    D->>D: Process Request
    D->>B: Broadcast Snapshot
    A->>B: Subscribe
    B-->>A: Stream Event (JSON)
```

- Added `sse.Broadcaster` to manage client connections.
- Integrated `Broadcaster` into `DNSDispatcher` to stream snapshots.
- Updated `RequestSnapshot` to track domain and status metadata.
- Added `/api/events` route to the Admin API group.