### PR TITLE
fix: change event time format to time.Time

### DIFF
--- a/internal/forwarder/dispatcher.go
+++ b/internal/forwarder/dispatcher.go
@@ -229,7 +229,7 @@ func (d *DNSDispatcher) snapshotWorker() {
 					ClientIP: snapshot.IPAddr(),
 					Source:   snapshot.Source(),
 					Blocked:  snapshot.IsBlocked(),
-					Time:     time.Now().Format(time.RFC3339),
+					Time:     time.Now(),
 				}
 
 				if d.geoIp != nil && snapshot.IPAddr() != "unknown" {

--- a/internal/http/sse/broadcaster.go
+++ b/internal/http/sse/broadcaster.go
@@ -3,16 +3,17 @@ package sse
 import (
 	"log/slog"
 	"sync"
+	"time"
 )
 
 type Event struct {
-	Domain   string `json:"domain"`
-	ClientIP string `json:"client_ip"`
-	Source   string `json:"source"`
-	Blocked  bool   `json:"blocked"`
-	ASN      string `json:"asn,omitempty"`
-	Country  string `json:"country,omitempty"`
-	Time     string `json:"time"`
+	Domain   string    `json:"domain"`
+	ClientIP string    `json:"client_ip"`
+	Source   string    `json:"source"`
+	Blocked  bool      `json:"blocked"`
+	ASN      string    `json:"asn,omitempty"`
+	Country  string    `json:"country,omitempty"`
+	Time     time.Time `json:"time"`
 }
 
 type Broadcaster struct {

--- a/internal/http/sse/broadcaster_test.go
+++ b/internal/http/sse/broadcaster_test.go
@@ -33,7 +33,7 @@ func TestBroadcaster(t *testing.T) {
 }
 
 func TestEventJSONMarshaling(t *testing.T) {
-	now := time.Now()
+	now := time.Date(2024, 1, 1, 12, 0, 0, 123456789, time.UTC)
 	event := Event{
 		Domain: "example.com",
 		Time:   now,
@@ -49,7 +49,5 @@ func TestEventJSONMarshaling(t *testing.T) {
 	timeStr, ok := m["time"].(string)
 	require.True(t, ok, "time field should be a string")
 
-	// RFC3339Nano includes fractional seconds if they are non-zero.
-	// We check if there's a dot in the timestamp, which indicates sub-second precision.
-	assert.Contains(t, timeStr, ".", "timestamp should include fractional seconds for millisecond accuracy")
+	assert.Equal(t, now.Format(time.RFC3339Nano), timeStr, "timestamp should match the expected RFC3339Nano format")
 }

--- a/internal/http/sse/broadcaster_test.go
+++ b/internal/http/sse/broadcaster_test.go
@@ -1,12 +1,14 @@
 package sse
 
 import (
+	"encoding/json"
 	"io"
 	"log/slog"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestBroadcaster(t *testing.T) {
@@ -28,4 +30,26 @@ func TestBroadcaster(t *testing.T) {
 	case <-time.After(100 * time.Millisecond):
 		t.Fatal("timed out waiting for message")
 	}
+}
+
+func TestEventJSONMarshaling(t *testing.T) {
+	now := time.Now()
+	event := Event{
+		Domain: "example.com",
+		Time:   now,
+	}
+
+	data, err := json.Marshal(event)
+	require.NoError(t, err)
+
+	var m map[string]any
+	err = json.Unmarshal(data, &m)
+	require.NoError(t, err)
+
+	timeStr, ok := m["time"].(string)
+	require.True(t, ok, "time field should be a string")
+
+	// RFC3339Nano includes fractional seconds if they are non-zero.
+	// We check if there's a dot in the timestamp, which indicates sub-second precision.
+	assert.Contains(t, timeStr, ".", "timestamp should include fractional seconds for millisecond accuracy")
 }


### PR DESCRIPTION
Switch the `Time` field in the SSE `Event` struct from a formatted string
to `time.Time` to allow for standard JSON marshaling and better precision. Added a test case to verify that fractional seconds are preserved during serialization.