### PR TITLE
feat: add sequence numbers to SSE broadcast events

### DIFF
--- a/internal/forwarder/dispatcher.go
+++ b/internal/forwarder/dispatcher.go
@@ -2,7 +2,6 @@ package forwarder
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"log/slog"
 	"net"
@@ -241,8 +240,7 @@ func (d *DNSDispatcher) snapshotWorker() {
 					}
 				}
 
-				msg, _ := json.Marshal(event)
-				d.broadcaster.Broadcast(msg)
+				d.broadcaster.Broadcast(event)
 			}
 		case <-d.done:
 			return

--- a/internal/forwarder/dispatcher.go
+++ b/internal/forwarder/dispatcher.go
@@ -224,11 +224,11 @@ func (d *DNSDispatcher) snapshotWorker() {
 			// Broadcast event in the background
 			if d.broadcaster != nil {
 				event := sse.Event{
-					Domain:   snapshot.PrimaryDomain(),
-					ClientIP: snapshot.IPAddr(),
-					Source:   snapshot.Source(),
-					Blocked:  snapshot.IsBlocked(),
-					Time:     time.Now(),
+					Domain:    snapshot.PrimaryDomain(),
+					ClientIP:  snapshot.IPAddr(),
+					Source:    snapshot.Source(),
+					Blocked:   snapshot.IsBlocked(),
+					Timestamp: time.Now(),
 				}
 
 				if d.geoIp != nil && snapshot.IPAddr() != "unknown" {

--- a/internal/http/routes/routes.go
+++ b/internal/http/routes/routes.go
@@ -49,11 +49,11 @@ func NewAdminGroup(r *gin.Engine, adminHost string, devMode bool, blocklistCheck
 
 				for {
 					select {
-					case msg, ok := <-subscriber:
+					case event, ok := <-subscriber:
 						if !ok {
 							return
 						}
-						c.SSEvent("message", string(msg))
+						c.SSEvent("message", event)
 						c.Writer.Flush()
 					case <-c.Request.Context().Done():
 						return

--- a/internal/http/sse/broadcaster.go
+++ b/internal/http/sse/broadcaster.go
@@ -3,23 +3,24 @@ package sse
 import (
 	"log/slog"
 	"sync"
+	"sync/atomic"
 	"time"
 )
 
 type Event struct {
-	Sequence uint64    `json:"sequence"`
-	Domain   string    `json:"domain"`
-	ClientIP string    `json:"client_ip"`
-	Source   string    `json:"source"`
-	Blocked  bool      `json:"blocked"`
-	ASN      string    `json:"asn,omitempty"`
-	Country  string    `json:"country,omitempty"`
-	Time     time.Time `json:"time"`
+	Timestamp time.Time `json:"ts"`
+	Sequence  uint64    `json:"seq"`
+	Domain    string    `json:"domain"`
+	ClientIP  string    `json:"ip"`
+	Source    string    `json:"src"`
+	Blocked   bool      `json:"blocked"`
+	ASN       string    `json:"asn,omitempty"`
+	Country   string    `json:"country,omitempty"`
 }
 
 type Broadcaster struct {
 	subscribers  map[chan Event]struct{}
-	nextSequence uint64
+	nextSequence atomic.Uint64
 	logger       *slog.Logger
 	mu           sync.RWMutex
 }
@@ -53,10 +54,7 @@ func (b *Broadcaster) Unsubscribe(ch chan Event) {
 }
 
 func (b *Broadcaster) Broadcast(event Event) {
-	b.mu.Lock()
-	event.Sequence = b.nextSequence
-	b.nextSequence++
-	b.mu.Unlock()
+	event.Sequence = b.nextSequence.Add(1)
 
 	b.mu.RLock()
 	defer b.mu.RUnlock()

--- a/internal/http/sse/broadcaster.go
+++ b/internal/http/sse/broadcaster.go
@@ -7,6 +7,7 @@ import (
 )
 
 type Event struct {
+	Sequence uint64    `json:"sequence"`
 	Domain   string    `json:"domain"`
 	ClientIP string    `json:"client_ip"`
 	Source   string    `json:"source"`
@@ -17,29 +18,30 @@ type Event struct {
 }
 
 type Broadcaster struct {
-	subscribers map[chan []byte]struct{}
-	logger      *slog.Logger
-	mu          sync.RWMutex
+	subscribers  map[chan Event]struct{}
+	nextSequence uint64
+	logger       *slog.Logger
+	mu           sync.RWMutex
 }
 
 func NewBroadcaster(logger *slog.Logger) *Broadcaster {
 	return &Broadcaster{
-		subscribers: make(map[chan []byte]struct{}),
+		subscribers: make(map[chan Event]struct{}),
 		logger:      logger,
 	}
 }
 
-func (b *Broadcaster) Subscribe() chan []byte {
+func (b *Broadcaster) Subscribe() chan Event {
 	b.logger.Debug("New subscriber added")
 	b.mu.Lock()
 	defer b.mu.Unlock()
 
-	ch := make(chan []byte, 10)
+	ch := make(chan Event, 10)
 	b.subscribers[ch] = struct{}{}
 	return ch
 }
 
-func (b *Broadcaster) Unsubscribe(ch chan []byte) {
+func (b *Broadcaster) Unsubscribe(ch chan Event) {
 	b.logger.Debug("Subscriber removed")
 	b.mu.Lock()
 	defer b.mu.Unlock()
@@ -50,13 +52,18 @@ func (b *Broadcaster) Unsubscribe(ch chan []byte) {
 	}
 }
 
-func (b *Broadcaster) Broadcast(msg []byte) {
+func (b *Broadcaster) Broadcast(event Event) {
+	b.mu.Lock()
+	event.Sequence = b.nextSequence
+	b.nextSequence++
+	b.mu.Unlock()
+
 	b.mu.RLock()
 	defer b.mu.RUnlock()
 
 	for ch := range b.subscribers {
 		select {
-		case ch <- msg:
+		case ch <- event:
 		default:
 			// Buffer full, drop message for this slow client
 		}

--- a/internal/http/sse/broadcaster_test.go
+++ b/internal/http/sse/broadcaster_test.go
@@ -20,13 +20,25 @@ func TestBroadcaster(t *testing.T) {
 	defer b.Unsubscribe(subscriber)
 
 	// Broadcast a message
-	msg := []byte("hello")
-	b.Broadcast(msg)
+	event := Event{Domain: "example.com"}
+	b.Broadcast(event)
 
 	// Verify receipt
 	select {
 	case received := <-subscriber:
-		assert.Equal(t, msg, received)
+		assert.Equal(t, "example.com", received.Domain)
+		assert.Equal(t, uint64(0), received.Sequence)
+	case <-time.After(100 * time.Millisecond):
+		t.Fatal("timed out waiting for message")
+	}
+
+	// Broadcast another message to check sequence
+	b.Broadcast(Event{Domain: "test.com"})
+
+	select {
+	case received := <-subscriber:
+		assert.Equal(t, "test.com", received.Domain)
+		assert.Equal(t, uint64(1), received.Sequence)
 	case <-time.After(100 * time.Millisecond):
 		t.Fatal("timed out waiting for message")
 	}

--- a/internal/http/sse/broadcaster_test.go
+++ b/internal/http/sse/broadcaster_test.go
@@ -27,7 +27,7 @@ func TestBroadcaster(t *testing.T) {
 	select {
 	case received := <-subscriber:
 		assert.Equal(t, "example.com", received.Domain)
-		assert.Equal(t, uint64(0), received.Sequence)
+		assert.Equal(t, uint64(1), received.Sequence)
 	case <-time.After(100 * time.Millisecond):
 		t.Fatal("timed out waiting for message")
 	}
@@ -38,7 +38,7 @@ func TestBroadcaster(t *testing.T) {
 	select {
 	case received := <-subscriber:
 		assert.Equal(t, "test.com", received.Domain)
-		assert.Equal(t, uint64(1), received.Sequence)
+		assert.Equal(t, uint64(2), received.Sequence)
 	case <-time.After(100 * time.Millisecond):
 		t.Fatal("timed out waiting for message")
 	}
@@ -47,8 +47,8 @@ func TestBroadcaster(t *testing.T) {
 func TestEventJSONMarshaling(t *testing.T) {
 	now := time.Date(2024, 1, 1, 12, 0, 0, 123456789, time.UTC)
 	event := Event{
-		Domain: "example.com",
-		Time:   now,
+		Domain:    "example.com",
+		Timestamp: now,
 	}
 
 	data, err := json.Marshal(event)
@@ -58,8 +58,8 @@ func TestEventJSONMarshaling(t *testing.T) {
 	err = json.Unmarshal(data, &m)
 	require.NoError(t, err)
 
-	timeStr, ok := m["time"].(string)
+	timestampStr, ok := m["ts"].(string)
 	require.True(t, ok, "time field should be a string")
 
-	assert.Equal(t, now.Format(time.RFC3339Nano), timeStr, "timestamp should match the expected RFC3339Nano format")
+	assert.Equal(t, now.Format(time.RFC3339Nano), timestampStr, "timestamp should match the expected RFC3339Nano format")
 }


### PR DESCRIPTION
Refactored the `Broadcaster` to handle `Event` structs instead of raw bytes, enabling the inclusion of a `sequence` field. This allows clients
 to track message ordering and detect missed events in the stream.

```mermaid
sequenceDiagram
    participant D as Dispatcher
    participant B as Broadcaster
    participant C as SSE Client

    D->>B: Broadcast(Event{Domain: "example.com"})
    Note over B: Set Sequence = N++
    B->>C: Push Event(Sequence: N, ...)
```