### PR TITLE
feat: add user authentication state via react-query

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -12,6 +12,7 @@
   "dependencies": {
     "@chakra-ui/react": "^3.36.0",
     "@emotion/react": "^11.14.0",
+    "@tanstack/react-query": "^5.101.2",
     "@tanstack/react-router": "^1.170.17",
     "next-themes": "^0.4.6",
     "react": "^19.2.7",

--- a/web/package.json
+++ b/web/package.json
@@ -23,6 +23,7 @@
     "@babel/core": "^8.0.1",
     "@eslint/js": "^10.0.1",
     "@rolldown/plugin-babel": "^0.2.3",
+    "@tanstack/react-query-devtools": "^5.101.2",
     "@tanstack/react-router-devtools": "^1.167.0",
     "@tanstack/router-cli": "^1.167.18",
     "@tanstack/router-devtools": "^1.167.0",

--- a/web/pnpm-lock.yaml
+++ b/web/pnpm-lock.yaml
@@ -14,6 +14,9 @@ importers:
       '@emotion/react':
         specifier: ^11.14.0
         version: 11.14.0(@types/react@19.2.17)(react@19.2.7)
+      '@tanstack/react-query':
+        specifier: ^5.101.2
+        version: 5.101.2(react@19.2.7)
       '@tanstack/react-router':
         specifier: ^1.170.17
         version: 1.170.17(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
@@ -508,6 +511,14 @@ packages:
   '@tanstack/history@1.162.0':
     resolution: {integrity: sha512-79pf/RkhteYZTRgcR4F9kbk84P2N8rugQJswxfIqovlbRiT3yI7eBE+5QorIrZaOKktsgzRlXh1l/du/xpl4iA==}
     engines: {node: '>=20.19'}
+
+  '@tanstack/query-core@5.101.2':
+    resolution: {integrity: sha512-hH5MLoJhF7KaIGd7q3xTXGXvslI+GYlM1Z/35aSHHWaCJWB7XvTSHYuV3eM7tw+aE0mT/xMro4M4Q9rCGHT0lw==}
+
+  '@tanstack/react-query@5.101.2':
+    resolution: {integrity: sha512-seDkr6kzGzX1okaaTtZPtgA688CDPlXUz1C6xSg0ESqn04Vuc8tlrYms1s3de+znBqhPVxFRfpAfUf+6XvfPWg==}
+    peerDependencies:
+      react: ^18 || ^19
 
   '@tanstack/react-router-devtools@1.167.0':
     resolution: {integrity: sha512-nGw095EG7IHx0h5NtlEmzf6vcCTaFNPWdTSuDKazajhN0ct/v/TkekJ9J6KYUCeV1a8/2ZmToc58M+0rrOyn7w==}
@@ -2284,6 +2295,13 @@ snapshots:
       tslib: 2.8.1
 
   '@tanstack/history@1.162.0': {}
+
+  '@tanstack/query-core@5.101.2': {}
+
+  '@tanstack/react-query@5.101.2(react@19.2.7)':
+    dependencies:
+      '@tanstack/query-core': 5.101.2
+      react: 19.2.7
 
   '@tanstack/react-router-devtools@1.167.0(@tanstack/react-router@1.170.17(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@tanstack/router-core@1.171.14)(csstype@3.2.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
     dependencies:

--- a/web/pnpm-lock.yaml
+++ b/web/pnpm-lock.yaml
@@ -42,6 +42,9 @@ importers:
       '@rolldown/plugin-babel':
         specifier: ^0.2.3
         version: 0.2.3(@babel/core@8.0.1)(@babel/runtime@7.29.7)(rolldown@1.1.5)(vite@8.1.4(@types/node@24.13.3)(jiti@2.7.0))
+      '@tanstack/react-query-devtools':
+        specifier: ^5.101.2
+        version: 5.101.2(@tanstack/react-query@5.101.2(react@19.2.7))(react@19.2.7)
       '@tanstack/react-router-devtools':
         specifier: ^1.167.0
         version: 1.167.0(@tanstack/react-router@1.170.17(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@tanstack/router-core@1.171.14)(csstype@3.2.3)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
@@ -517,6 +520,15 @@ packages:
 
   '@tanstack/query-core@5.101.2':
     resolution: {integrity: sha512-hH5MLoJhF7KaIGd7q3xTXGXvslI+GYlM1Z/35aSHHWaCJWB7XvTSHYuV3eM7tw+aE0mT/xMro4M4Q9rCGHT0lw==}
+
+  '@tanstack/query-devtools@5.101.2':
+    resolution: {integrity: sha512-o+wHcqgN7Pp0s8v1i0UGq/ZrrEKrxdIiMQmKRdYb2w7NPtylYSJ4+wg/tIn71m9DLstwUwdEGAvROdly6HXP6w==}
+
+  '@tanstack/react-query-devtools@5.101.2':
+    resolution: {integrity: sha512-eU7HctdA9gDjqoERoEdzLbw9DiqnBDfh5+Hu0u26gjqoHJezOpQAuiesDL2VvkU+2cPV76zgv0tMZsOrI4LjnQ==}
+    peerDependencies:
+      '@tanstack/react-query': ^5.101.2
+      react: ^18 || ^19
 
   '@tanstack/react-query@5.101.2':
     resolution: {integrity: sha512-seDkr6kzGzX1okaaTtZPtgA688CDPlXUz1C6xSg0ESqn04Vuc8tlrYms1s3de+znBqhPVxFRfpAfUf+6XvfPWg==}
@@ -2300,6 +2312,14 @@ snapshots:
   '@tanstack/history@1.162.0': {}
 
   '@tanstack/query-core@5.101.2': {}
+
+  '@tanstack/query-devtools@5.101.2': {}
+
+  '@tanstack/react-query-devtools@5.101.2(@tanstack/react-query@5.101.2(react@19.2.7))(react@19.2.7)':
+    dependencies:
+      '@tanstack/query-devtools': 5.101.2
+      '@tanstack/react-query': 5.101.2(react@19.2.7)
+      react: 19.2.7
 
   '@tanstack/react-query@5.101.2(react@19.2.7)':
     dependencies:

--- a/web/src/components/Navbar.tsx
+++ b/web/src/components/Navbar.tsx
@@ -1,5 +1,6 @@
-import { Box, Flex, HStack, Avatar, Span } from '@chakra-ui/react'
+import { Box, Flex, HStack, Span } from '@chakra-ui/react'
 import { RouterLink } from '@/components/ui/router-link'
+import { UserAvatar } from './UserAvatar'
 
 export function Navbar() {
   return (
@@ -34,10 +35,7 @@ export function Navbar() {
           </HStack>
         </HStack>
 
-        <Avatar.Root size="sm">
-          <Avatar.Fallback name="User Name" />
-          <Avatar.Image src="https://bit.ly/broken-link" />
-        </Avatar.Root>
+        <UserAvatar />
       </Flex>
     </Box>
   )

--- a/web/src/components/UserAvatar.tsx
+++ b/web/src/components/UserAvatar.tsx
@@ -20,14 +20,10 @@ export function UserAvatar() {
     return null;
   }
 
-  const gravatarUrl = `https://www.gravatar.com/avatar/${encodeURIComponent(
-    data.email.trim().toLowerCase()
-  )}`
-
   return (
     <Avatar.Root size="sm" colorPalette={pickPalette(data.user)}>
       <Avatar.Fallback name={data.user} />
-      <Avatar.Image src={gravatarUrl} />
+      <Avatar.Image src={`https://www.gravatar.com/avatar/${data.emailHash}`} />
     </Avatar.Root>
   )
 }

--- a/web/src/components/UserAvatar.tsx
+++ b/web/src/components/UserAvatar.tsx
@@ -17,7 +17,6 @@ export function UserAvatar() {
     retry: false,
   })
 
-  console.log({ data })
   if (isLoading || error || !data) {
     return null;
   }

--- a/web/src/components/UserAvatar.tsx
+++ b/web/src/components/UserAvatar.tsx
@@ -1,0 +1,33 @@
+import { fetchWhoAmI } from '@/service/whoami'
+import { Avatar } from '@chakra-ui/react'
+import { useQuery } from '@tanstack/react-query'
+
+const colorPalette = ["red", "blue", "green", "yellow", "purple", "orange"]
+
+const pickPalette = (name: string) => {
+  const index = name.charCodeAt(0) % colorPalette.length
+  return colorPalette[index]
+}
+
+export function UserAvatar() {
+  const { data, isLoading, error } = useQuery({
+    queryKey: ['whoami'],
+    queryFn: fetchWhoAmI,
+  })
+
+  console.log({ data })
+  if (isLoading || error || !data) {
+    return null;
+  }
+
+  const gravatarUrl = `https://www.gravatar.com/avatar/${encodeURIComponent(
+    data.email.trim().toLowerCase()
+  )}`
+
+  return (
+    <Avatar.Root size="sm" colorPalette={pickPalette(data.user)}>
+      <Avatar.Fallback name={data.user} />
+      <Avatar.Image src={gravatarUrl} />
+    </Avatar.Root>
+  )
+}

--- a/web/src/components/UserAvatar.tsx
+++ b/web/src/components/UserAvatar.tsx
@@ -5,6 +5,7 @@ import { useQuery } from '@tanstack/react-query'
 const colorPalette = ["red", "blue", "green", "yellow", "purple", "orange"]
 
 const pickPalette = (name: string) => {
+  if (!name) return colorPalette[0]
   const index = name.charCodeAt(0) % colorPalette.length
   return colorPalette[index]
 }

--- a/web/src/components/UserAvatar.tsx
+++ b/web/src/components/UserAvatar.tsx
@@ -13,6 +13,7 @@ export function UserAvatar() {
   const { data, isLoading, error } = useQuery({
     queryKey: ['whoami'],
     queryFn: fetchWhoAmI,
+    retry: false,
   })
 
   console.log({ data })

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -1,8 +1,10 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { RouterProvider, createRouter } from "@tanstack/react-router"
 import React from "react"
 import ReactDOM from "react-dom/client"
 import { routeTree } from "./routeTree.gen"
 
+const queryClient = new QueryClient()
 const router = createRouter({ routeTree })
 
 declare module "@tanstack/react-router" {
@@ -13,6 +15,8 @@ declare module "@tanstack/react-router" {
 
 ReactDOM.createRoot(document.getElementById("root")!).render(
   <React.StrictMode>
-    <RouterProvider router={router} />
+    <QueryClientProvider client={queryClient}>
+      <RouterProvider router={router} />
+    </QueryClientProvider>
   </React.StrictMode>,
 )

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -1,4 +1,5 @@
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { ReactQueryDevtools } from '@tanstack/react-query-devtools'
 import { RouterProvider, createRouter } from "@tanstack/react-router"
 import React from "react"
 import ReactDOM from "react-dom/client"
@@ -17,6 +18,7 @@ ReactDOM.createRoot(document.getElementById("root")!).render(
   <React.StrictMode>
     <QueryClientProvider client={queryClient}>
       <RouterProvider router={router} />
+      <ReactQueryDevtools initialIsOpen={false} />
     </QueryClientProvider>
   </React.StrictMode>,
 )

--- a/web/src/service/whoami.ts
+++ b/web/src/service/whoami.ts
@@ -1,0 +1,12 @@
+interface User {
+  user: string
+  email: string
+}
+
+export async function fetchWhoAmI(): Promise<User> {
+  const response = await fetch('/api/whoami')
+  if (!response.ok) {
+    throw new Error('Failed to fetch user info')
+  }
+  return response.json()
+}

--- a/web/src/service/whoami.ts
+++ b/web/src/service/whoami.ts
@@ -1,12 +1,22 @@
-interface User {
-  user: string
-  email: string
+export interface User {
+  user: string;
+  email: string;
+  emailHash: string;
+}
+
+async function sha256(message: string): Promise<string> {
+  const msgBuffer = new TextEncoder().encode(message);
+  const hashBuffer = await crypto.subtle.digest("SHA-256", msgBuffer);
+  const hashArray = Array.from(new Uint8Array(hashBuffer));
+  return hashArray.map((b) => b.toString(16).padStart(2, "0")).join("");
 }
 
 export async function fetchWhoAmI(): Promise<User> {
-  const response = await fetch('/api/whoami')
+  const response = await fetch("/api/whoami");
   if (!response.ok) {
-    throw new Error('Failed to fetch user info')
+    throw new Error("Failed to fetch user info");
   }
-  return response.json()
+  const data = await response.json();
+  const emailHash = await sha256(data.email.trim().toLowerCase());
+  return { ...data, emailHash };
 }

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -25,7 +25,7 @@ export default defineConfig(() => {
     },
     server: {
       proxy: {
-        "/api": "http://localhost:8080",
+        "/api": "http://admin.localhost:8080",
       },
     },
     resolve: {


### PR DESCRIPTION
Integrate `@tanstack/react-query` to manage user identity state. Added a
 `UserAvatar` component that dynamically fetches user data and displays
a Gravatar with a seeded color palette.

```mermaid
sequenceDiagram
    participant App as React App
    participant QC as QueryClient
    participant API as /api/whoami

    App->>QC: useQuery(['whoami'])
    QC->>API: fetch('/api/whoami')
    API-->>QC: { user, email }
    QC-->>App: data (resolved)
    App->>App: Render UserAvatar with Gravatar
```

- Installed `@tanstack/react-query`
- Added `QueryClientProvider` to the root entry point
- Created `fetchWhoAmI` service
- Updated API proxy target to `admin.localhost`