### PR TITLE
fix: remove GeoIP dependency from DNS dispatcher

### DIFF
--- a/internal/app.go
+++ b/internal/app.go
@@ -224,7 +224,7 @@ func (app *App) RunServer(ctx context.Context) error {
 	}
 
 	broadcaster := sse.NewBroadcaster(app.Logger)
-	dispatcher, err := forwarder.NewDNSDispatcher(cache, metrics, dnsClient, blockList, noiseFilter, geoIpLookup, broadcaster, app.CacheTtlFloor, app.Logger, app.EnableECS)
+	dispatcher, err := forwarder.NewDNSDispatcher(cache, metrics, dnsClient, blockList, noiseFilter, broadcaster, app.CacheTtlFloor, app.Logger, app.EnableECS)
 	if err != nil {
 		return errors.Wrap(err, "failed to create dispatcher")
 	}

--- a/internal/forwarder/dispatcher.go
+++ b/internal/forwarder/dispatcher.go
@@ -11,7 +11,6 @@ import (
 	"github.com/cockroachdb/errors"
 	"github.com/miekg/dns"
 	"github.com/rm-hull/dot-block/internal/blocklist"
-	"github.com/rm-hull/dot-block/internal/geoblock"
 	"github.com/rm-hull/dot-block/internal/http/sse"
 	"github.com/rm-hull/dot-block/internal/metrics"
 	"github.com/rm-hull/dot-block/internal/noisefilter"
@@ -59,7 +58,6 @@ type DNSDispatcher struct {
 	metrics     *metrics.DnsMetrics
 	logger      *slog.Logger
 	noiseFilter *noisefilter.NoiseFilter
-	geoIp       geoblock.GeoIpLookup
 	broadcaster *sse.Broadcaster
 	enableECS   bool
 	snapshotCh  chan *metrics.RequestSnapshot
@@ -72,7 +70,6 @@ func NewDNSDispatcher(
 	dnsClient *RoundRobinClient,
 	blockList *blocklist.BlockList,
 	noiseFilter *noisefilter.NoiseFilter,
-	geoIp geoblock.GeoIpLookup,
 	broadcaster *sse.Broadcaster,
 	ttlFloor time.Duration,
 	logger *slog.Logger,
@@ -92,7 +89,6 @@ func NewDNSDispatcher(
 		metrics:     dnsMetrics,
 		logger:      logger,
 		noiseFilter: noiseFilter,
-		geoIp:       geoIp,
 		broadcaster: broadcaster,
 		enableECS:   enableECS,
 		snapshotCh:  make(chan *metrics.RequestSnapshot, SNAPSHOT_BUFFER_SIZE),
@@ -221,7 +217,6 @@ func (d *DNSDispatcher) snapshotWorker() {
 			}
 			snapshot.Record(d.metrics)
 
-			// Broadcast event in the background
 			if d.broadcaster != nil {
 				event := sse.Event{
 					Domain:    snapshot.PrimaryDomain(),
@@ -229,15 +224,6 @@ func (d *DNSDispatcher) snapshotWorker() {
 					Source:    snapshot.Source(),
 					Blocked:   snapshot.IsBlocked(),
 					Timestamp: time.Now(),
-				}
-
-				if d.geoIp != nil && snapshot.IPAddr() != "unknown" {
-					if geodata, err := d.geoIp.GetAll(snapshot.IPAddr()); err == nil && geodata != nil {
-						event.Country = geodata.ISOCode
-						if geodata.ASN != "" && geodata.Provider != "" {
-							event.ASN = geodata.ASN + ":" + geodata.Provider
-						}
-					}
 				}
 
 				d.broadcaster.Broadcast(event)

--- a/internal/forwarder/dispatcher_test.go
+++ b/internal/forwarder/dispatcher_test.go
@@ -96,7 +96,7 @@ func setupDispatcherTest(t *testing.T, upstream string, logger *slog.Logger, ena
 	dnsClient, err := NewRoundRobinClient(metrics, 2*time.Second, 2*time.Second, 2*time.Second, logger, upstream)
 	require.NoError(t, err)
 
-	dispatcher, err := NewDNSDispatcher(cache, metrics, dnsClient, blockList, noisefilter.NewNoiseFilter(), mockGeo, sse.NewBroadcaster(logger), 1*time.Minute, logger, enableECS)
+	dispatcher, err := NewDNSDispatcher(cache, metrics, dnsClient, blockList, noisefilter.NewNoiseFilter(), sse.NewBroadcaster(logger), 1*time.Minute, logger, enableECS)
 	require.NoError(t, err)
 	t.Cleanup(dispatcher.Close)
 
@@ -388,7 +388,7 @@ func TestDNSDispatcher_NegativeCacheTtlFloor(t *testing.T) {
 	dnsClient, err := NewRoundRobinClient(metrics, 2*time.Second, 2*time.Second, 2*time.Second, logger, "8.8.8.8:53")
 	assert.NoError(t, err)
 
-	dispatcher, err := NewDNSDispatcher(cache, metrics, dnsClient, blockList, noisefilter.NewNoiseFilter(), mockGeo, sse.NewBroadcaster(logger), -1*time.Second, logger, false)
+	dispatcher, err := NewDNSDispatcher(cache, metrics, dnsClient, blockList, noisefilter.NewNoiseFilter(), sse.NewBroadcaster(logger), -1*time.Second, logger, false)
 	assert.Error(t, err)
 	assert.Nil(t, dispatcher)
 	assert.Contains(t, err.Error(), "TTL floor cannot be negative")
@@ -714,7 +714,7 @@ func TestDNSDispatcher_ECS_Injection(t *testing.T) {
 			metrics, _ := metrics.NewDNSMetrics(cache, mockGeo)
 			dnsClient, _ := NewRoundRobinClient(metrics, 2*time.Second, 2*time.Second, 2*time.Second, logger, upstream)
 
-			dispatcher, _ := NewDNSDispatcher(cache, metrics, dnsClient, blockList, noisefilter.NewNoiseFilter(), mockGeo, sse.NewBroadcaster(logger), 1*time.Minute, logger, tt.enableECS)
+			dispatcher, _ := NewDNSDispatcher(cache, metrics, dnsClient, blockList, noisefilter.NewNoiseFilter(), sse.NewBroadcaster(logger), 1*time.Minute, logger, tt.enableECS)
 			defer dispatcher.Close()
 
 			// Mock ResponseWriter with the specific client IP

--- a/internal/http/sse/broadcaster.go
+++ b/internal/http/sse/broadcaster.go
@@ -14,8 +14,6 @@ type Event struct {
 	ClientIP  string    `json:"ip"`
 	Source    string    `json:"src"`
 	Blocked   bool      `json:"blocked"`
-	ASN       string    `json:"asn,omitempty"`
-	Country   string    `json:"country,omitempty"`
 }
 
 type Broadcaster struct {


### PR DESCRIPTION
Cleaned up the `DNSDispatcher` by removing the `GeoIpLookup` dependency and associated fields in SSE events, as they are no longer processed within the dispatcher's snapshot logic.