### PR TITLE
feat: add ASN lookup API and reorganize admin routes

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,8 +156,8 @@ If `--metrics-auth` is configured, the `/metrics` endpoint is protected by basic
 
 While the public endpoints are available on the main domain, the management APIs are hosted on the admin subdomain (e.g., `admin.dot.your-domain.com`):
 
-- `POST /api/reload`: Triggers an asynchronous reload of the blocklists.
-- `POST /api/check`: Checks whether provided domains are blocked. Accepts a JSON array of strings or a newline-separated list of domains in the request body.
+- `POST /api/blocklist/reload`: Triggers an asynchronous reload of the blocklists.
+- `POST /api/blocklist/check`: Checks whether provided domains are blocked. Accepts a JSON array of strings or a newline-separated list of domains in the request body.
 - `GET /api/whoami`: Returns information about the currently authenticated user.
 - `GET /api/events`: Streams live DNS requests via Server-Sent Events (SSE). Each event is a JSON object containing the queried domain, client IP, source (UDP/TCP/DoT/DoH), whether it was blocked, and GeoIP data (ASN and Country ISO code).
 

--- a/internal/app.go
+++ b/internal/app.go
@@ -230,7 +230,7 @@ func (app *App) RunServer(ctx context.Context) error {
 	}
 	defer dispatcher.Close()
 
-	r, err := app.startHttpServer(dnsClient, blocklistUpdater, dispatcher)
+	r, err := app.startHttpServer(dnsClient, blocklistUpdater, dispatcher, geoIpLookup)
 	if err != nil {
 		return errors.Wrap(err, "failed to initialize HTTP server")
 	}
@@ -365,7 +365,13 @@ func (app *App) newProxyListener(base net.Listener) (*proxyproto.Listener, error
 	return proxyListener, nil
 }
 
-func (app *App) startHttpServer(dnsClient *forwarder.RoundRobinClient, blocklistUpdater *blocklist.BlocklistUpdater, dispatcher *forwarder.DNSDispatcher) (*gin.Engine, error) {
+func (app *App) startHttpServer(
+	dnsClient *forwarder.RoundRobinClient,
+	blocklistUpdater *blocklist.BlocklistUpdater,
+	dispatcher *forwarder.DNSDispatcher,
+	geoIpLookup geoblock.GeoIpLookup,
+) (*gin.Engine, error) {
+
 	if !app.DevMode {
 		gin.SetMode(gin.ReleaseMode)
 	}
@@ -414,7 +420,9 @@ func (app *App) startHttpServer(dnsClient *forwarder.RoundRobinClient, blocklist
 	routes.NewAdminGroup(r, "admin."+serverName, app.DevMode,
 		blocklistHandler.Check,
 		blocklistHandler.Reload,
-		dispatcher.GetBroadcaster())
+		dispatcher.GetBroadcaster(),
+		geoIpLookup,
+	)
 
 	return r, nil
 }

--- a/internal/forwarder/dispatcher_test.go
+++ b/internal/forwarder/dispatcher_test.go
@@ -26,13 +26,17 @@ type MockGeoIpLookup struct {
 	mock.Mock
 }
 
-func (m *MockGeoIpLookup) GetAll(ipAddress string) (*geoblock.GeoData, error) {
-	args := m.Called(ipAddress)
+func (m *MockGeoIpLookup) GetAll(ipAddr string) (*geoblock.GeoData, error) {
+	args := m.Called(ipAddr)
 	return new(args.Get(0).(geoblock.GeoData)), args.Error(1)
 }
 
 func (m *MockGeoIpLookup) Reopen() error {
 	return nil
+}
+
+func (m *MockGeoIpLookup) IsValid(ipAddr string) bool {
+	return true
 }
 
 // MockResponseWriter is a mock implementation of dns.ResponseWriter.

--- a/internal/geoblock/service.go
+++ b/internal/geoblock/service.go
@@ -19,7 +19,8 @@ type GeoData struct {
 
 type GeoIpLookup interface {
 	Reopen() error
-	GetAll(ipAddress string) (*GeoData, error)
+	GetAll(ipAddr string) (*GeoData, error)
+	IsValid(ipAddr string) bool
 }
 
 type geoBlocker struct {
@@ -60,7 +61,7 @@ func (g *geoBlocker) Reopen() error {
 	return nil
 }
 
-func (g *geoBlocker) GetAll(ipAddress string) (*GeoData, error) {
+func (g *geoBlocker) GetAll(ipAddr string) (*GeoData, error) {
 	g.mu.RLock()
 	defer g.mu.RUnlock()
 
@@ -68,16 +69,25 @@ func (g *geoBlocker) GetAll(ipAddress string) (*GeoData, error) {
 		return nil, errors.New("geoblock database not initialized")
 	}
 
-	ip, err := netip.ParseAddr(ipAddress)
+	ip, err := netip.ParseAddr(ipAddr)
 	if err != nil {
-		return nil, errors.Newf("invalid IP address: %w", err)
+		return nil, errors.Wrap(err, "invalid IP address")
 	}
 
 	var geodata GeoData
 	err = g.db.Lookup(ip).Decode(&geodata)
 	if err != nil {
-		return nil, err
+		return nil, errors.Wrap(err, "failed to decode response")
+	}
+
+	if geodata.ISOCode == "" && geodata.Country == "" && geodata.ASN == "" && geodata.Provider == "" && geodata.Domain == "" {
+		return nil, nil
 	}
 
 	return &geodata, nil
+}
+
+func (g *geoBlocker) IsValid(ipAddr string) bool {
+	_, err := netip.ParseAddr(ipAddr)
+	return err == nil
 }

--- a/internal/http/routes/routes.go
+++ b/internal/http/routes/routes.go
@@ -122,6 +122,10 @@ func whoAmIHandler(c *gin.Context) {
 
 func asnLookupHandler(geoIp geoblock.GeoIpLookup) gin.HandlerFunc {
 	return func(c *gin.Context) {
+		if geoIp == nil {
+			c.AbortWithStatusJSON(http.StatusServiceUnavailable, gin.H{"error": "GeoIP lookup service is disabled"})
+			return
+		}
 		ipAddr := c.Param("ip")
 		if ipAddr == "" {
 			c.AbortWithStatusJSON(http.StatusBadRequest, gin.H{"error": "missing IP address"})

--- a/internal/http/routes/routes.go
+++ b/internal/http/routes/routes.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/gin-gonic/gin"
+	"github.com/rm-hull/dot-block/internal/geoblock"
 	"github.com/rm-hull/dot-block/internal/http/handlers"
 	"github.com/rm-hull/dot-block/internal/http/middlewares"
 	"github.com/rm-hull/dot-block/internal/http/sse"
@@ -24,7 +25,15 @@ func NewPublicGroup(r *gin.Engine, publicHost string, mobileConfigHandler gin.Ha
 	return public
 }
 
-func NewAdminGroup(r *gin.Engine, adminHost string, devMode bool, blocklistCheckHandler gin.HandlerFunc, blocklistReloadHandler gin.HandlerFunc, broadcaster *sse.Broadcaster) *gin.RouterGroup {
+func NewAdminGroup(
+	r *gin.Engine,
+	adminHost string,
+	devMode bool,
+	blocklistCheckHandler gin.HandlerFunc,
+	blocklistReloadHandler gin.HandlerFunc,
+	broadcaster *sse.Broadcaster,
+	geoIp geoblock.GeoIpLookup,
+) *gin.RouterGroup {
 
 	// --- Admin: SPA + API, pinned to the admin host, auth on top ---
 	admin := r.Group("/")
@@ -33,41 +42,11 @@ func NewAdminGroup(r *gin.Engine, adminHost string, devMode bool, blocklistCheck
 		api := admin.Group("/api")
 		api.Use(middlewares.RequireProxyAuth(devMode))
 		{
-			api.POST("/check", blocklistCheckHandler)
-			api.POST("/reload", blocklistReloadHandler)
-			api.GET("/events", func(c *gin.Context) {
-				if broadcaster == nil {
-					c.AbortWithStatus(http.StatusServiceUnavailable)
-					return
-				}
-				subscriber := broadcaster.Subscribe()
-				defer broadcaster.Unsubscribe(subscriber)
-
-				c.Header("Content-Type", "text/event-stream")
-				c.Header("Cache-Control", "no-cache")
-				c.Header("Connection", "keep-alive")
-
-				for {
-					select {
-					case event, ok := <-subscriber:
-						if !ok {
-							return
-						}
-						c.SSEvent("message", event)
-						c.Writer.Flush()
-					case <-c.Request.Context().Done():
-						return
-					}
-				}
-			})
-			api.GET("/whoami", func(c *gin.Context) {
-				user, _ := c.Get("user")
-				email, _ := c.Get("email")
-				c.JSON(http.StatusOK, gin.H{
-					"user":  user,
-					"email": email,
-				})
-			})
+			api.POST("/blocklist/check", blocklistCheckHandler)
+			api.POST("/blocklist/reload", blocklistReloadHandler)
+			api.GET("/asn/:ip", asnLookupHandler(geoIp))
+			api.GET("/events", sseHandler(broadcaster))
+			api.GET("/whoami", whoAmIHandler)
 		}
 
 		distFS := web.DistFS()
@@ -102,4 +81,68 @@ func NewAdminGroup(r *gin.Engine, adminHost string, devMode bool, blocklistCheck
 	}
 
 	return admin
+}
+
+func sseHandler(broadcaster *sse.Broadcaster) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		if broadcaster == nil {
+			c.AbortWithStatus(http.StatusServiceUnavailable)
+			return
+		}
+		subscriber := broadcaster.Subscribe()
+		defer broadcaster.Unsubscribe(subscriber)
+
+		c.Header("Content-Type", "text/event-stream")
+		c.Header("Cache-Control", "no-cache")
+		c.Header("Connection", "keep-alive")
+
+		for {
+			select {
+			case event, ok := <-subscriber:
+				if !ok {
+					return
+				}
+				c.SSEvent("message", event)
+				c.Writer.Flush()
+			case <-c.Request.Context().Done():
+				return
+			}
+		}
+	}
+}
+
+func whoAmIHandler(c *gin.Context) {
+	user, _ := c.Get("user")
+	email, _ := c.Get("email")
+	c.JSON(http.StatusOK, gin.H{
+		"user":  user,
+		"email": email,
+	})
+}
+
+func asnLookupHandler(geoIp geoblock.GeoIpLookup) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		ipAddr := c.Param("ip")
+		if ipAddr == "" {
+			c.AbortWithStatusJSON(http.StatusBadRequest, gin.H{"error": "missing IP address"})
+			return
+		}
+		if !geoIp.IsValid(ipAddr) {
+			c.AbortWithStatusJSON(http.StatusBadRequest, gin.H{"error": "invalid IP address"})
+			return
+		}
+
+		geoData, err := geoIp.GetAll(ipAddr)
+		if err != nil {
+			_ = c.Error(err)
+			c.AbortWithStatus(http.StatusInternalServerError)
+			return
+		}
+		if geoData == nil {
+			c.AbortWithStatus(http.StatusNotFound)
+			return
+		}
+
+		c.JSON(http.StatusOK, geoData)
+	}
 }

--- a/internal/http/routes/routes_test.go
+++ b/internal/http/routes/routes_test.go
@@ -1,0 +1,42 @@
+package routes
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/rm-hull/dot-block/internal/geoblock"
+	"github.com/stretchr/testify/require"
+)
+
+type stubGeoIpLookup struct {
+	valid   bool
+	geoData *geoblock.GeoData
+	err     error
+}
+
+func (s *stubGeoIpLookup) Reopen() error { return nil }
+func (s *stubGeoIpLookup) GetAll(ipAddr string) (*geoblock.GeoData, error) {
+	return s.geoData, s.err
+}
+func (s *stubGeoIpLookup) IsValid(ipAddr string) bool { return s.valid }
+
+func TestAsnLookupHandlerReturnsNotFoundForEmptyGeoData(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	lookup := &stubGeoIpLookup{
+		valid:   true,
+		geoData: nil,
+	}
+	handler := asnLookupHandler(lookup)
+
+	w := httptest.NewRecorder()
+	ctx, _ := gin.CreateTestContext(w)
+	ctx.Request = httptest.NewRequest(http.MethodGet, "/api/asn/8.8.8.8", nil)
+	ctx.Params = gin.Params{{Key: "ip", Value: "8.8.8.8"}}
+
+	handler(ctx)
+
+	require.Equal(t, http.StatusNotFound, w.Code)
+}

--- a/test.http
+++ b/test.http
@@ -19,22 +19,25 @@ GET http://localhost:8080/.mobileconfig
 
 
 ### Reload blocklist
-POST http://admin.localhost:8080/api/reload
+POST http://admin.localhost:8080/api/blocklist/reload
 User-Agent: test-client
 
 ### Check blocklist (JSON)
-POST http://admin.localhost:8080/api/check
+POST http://admin.localhost:8080/api/blocklist/check
 Content-Type: application/json
 
 ["google.com", "www.ex.co", "ads.net"]
 
 ### Check blocklist (Plain text)
-POST http://admin.localhost:8080/api/check
+POST http://admin.localhost:8080/api/blocklist/check
 Content-Type: text/plain
 
 google.com
 www.ex.co
 ads.net
+
+### ASN Lookup
+GET http://admin.localhost:8080/api/asn/24.123.12.0
 
 ### DoH POST
 POST http://localhost:8080/dns-query


### PR DESCRIPTION
- Refactored `/api` endpoints to use `/api/blocklist/` prefix for consistency.
- Introduced `GET /api/asn/:ip` to allow manual GeoIP lookups.
- Added `IsValid` and nil-handling logic to the `GeoIpLookup` service.
- Improved code modularity in `internal/http/routes` by extracting handler functions.