### PR TITLE
feat: add temporal blocklist disable functionality

### DIFF
--- a/internal/app.go
+++ b/internal/app.go
@@ -418,8 +418,7 @@ func (app *App) startHttpServer(
 		handlers.NewDoHHandler(requestHandler))
 
 	routes.NewAdminGroup(r, "admin."+serverName, app.DevMode,
-		blocklistHandler.Check,
-		blocklistHandler.Reload,
+		blocklistHandler,
 		dispatcher.GetBroadcaster(),
 		geoIpLookup,
 	)

--- a/internal/blocklist/blocklist.go
+++ b/internal/blocklist/blocklist.go
@@ -57,7 +57,6 @@ func (blockList *BlockList) IsBlocked(fqdn string) (bool, error) {
 	if isBlocked {
 		// Check if blocklist is temporarily disabled
 		if blockList.disabledUntil != nil && time.Now().Before(*blockList.disabledUntil) {
-			blockList.logger.Warn("Blocked domain query, but blocklist is temporarily disabled", "domain", domain)
 			return false, nil
 		}
 		return true, nil
@@ -100,7 +99,7 @@ func (blocklist *BlockList) Reenable() bool {
 
 type BlocklistStatus struct {
 	Disabled          bool       `json:"disabled"`
-	Unitl             *time.Time `json:"until,omitempty"`
+	Until             *time.Time `json:"until,omitempty"`
 	ApproxSize        uint32     `json:"approx_size"`
 	FalsePositiveRate float64    `json:"false_positive_rate"`
 }
@@ -110,9 +109,14 @@ func (blocklist *BlockList) Status() *BlocklistStatus {
 	blocklist.mutex.RLock()
 	defer blocklist.mutex.RUnlock()
 
+	var until *time.Time
+	disabled := blocklist.disabledUntil != nil && time.Now().Before(*blocklist.disabledUntil)
+	if disabled {
+		until = blocklist.disabledUntil
+	}
 	status := BlocklistStatus{
-		Disabled:          blocklist.disabledUntil != nil && time.Now().Before(*blocklist.disabledUntil),
-		Unitl:             blocklist.disabledUntil,
+		Disabled:          disabled,
+		Until:             until,
 		ApproxSize:        blocklist.bloomFilter.ApproximatedSize(),
 		FalsePositiveRate: blocklist.fpRate,
 	}

--- a/internal/blocklist/blocklist.go
+++ b/internal/blocklist/blocklist.go
@@ -4,6 +4,7 @@ import (
 	"log/slog"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/bits-and-blooms/bloom/v3"
 	"github.com/rm-hull/dot-block/internal/metrics"
@@ -11,11 +12,12 @@ import (
 )
 
 type BlockList struct {
-	fpRate      float64
-	bloomFilter *bloom.BloomFilter
-	metrics     *metrics.BlockListMetrics
-	logger      *slog.Logger
-	mutex       *sync.RWMutex
+	fpRate        float64
+	bloomFilter   *bloom.BloomFilter
+	metrics       *metrics.BlockListMetrics
+	logger        *slog.Logger
+	mutex         *sync.RWMutex
+	disabledUntil *time.Time
 }
 
 func NewBlockList(items []string, fpRate float64, logger *slog.Logger) *BlockList {
@@ -35,7 +37,6 @@ func NewBlockList(items []string, fpRate float64, logger *slog.Logger) *BlockLis
 // Returns whether the URL (or part of the URL) is on a block list.
 // If true, might be a false positive, but if false (i.e. allowed) is definitely not blocked
 func (blockList *BlockList) IsBlocked(fqdn string) (bool, error) {
-
 	domain, _ := strings.CutSuffix(fqdn, ".")
 
 	blockList.mutex.RLock()
@@ -43,21 +44,26 @@ func (blockList *BlockList) IsBlocked(fqdn string) (bool, error) {
 
 	isBlocked := blockList.bloomFilter.TestString(domain)
 
-	if isBlocked {
-		return true, nil
-	}
-
 	// Try the apex domain
 	apexDomain, err := publicsuffix.EffectiveTLDPlusOne(domain)
 	if err != nil {
-		// ignore: the domain effectively /is/ the apex domain - see https://publicsuffix.org/learn/
-		if strings.HasPrefix(err.Error(), "publicsuffix: cannot derive eTLD+1") {
-			return false, nil
+		if !strings.HasPrefix(err.Error(), "publicsuffix: cannot derive eTLD+1") {
+			return false, err
 		}
-		return false, err
+	} else if !isBlocked {
+		isBlocked = blockList.bloomFilter.TestString(apexDomain)
 	}
 
-	return blockList.bloomFilter.TestString(apexDomain), nil
+	if isBlocked {
+		// Check if blocklist is temporarily disabled
+		if blockList.disabledUntil != nil && time.Now().Before(*blockList.disabledUntil) {
+			blockList.logger.Warn("Blocked domain query, but blocklist is temporarily disabled", "domain", domain)
+			return false, nil
+		}
+		return true, nil
+	}
+
+	return false, nil
 }
 
 func (blocklist *BlockList) Load(items []string) {
@@ -68,6 +74,50 @@ func (blocklist *BlockList) Load(items []string) {
 	}
 
 	blocklist.ApplyBloomFilter(bf, n)
+}
+
+func (blocklist *BlockList) Disable(duration time.Duration) time.Time {
+	t := time.Now().Add(duration)
+	blocklist.mutex.Lock()
+	blocklist.disabledUntil = &t
+	blocklist.mutex.Unlock()
+	blocklist.logger.Warn("Blocklist temporarily disabled", "until", t)
+	return t
+}
+
+func (blocklist *BlockList) Reenable() bool {
+	blocklist.mutex.Lock()
+	defer blocklist.mutex.Unlock()
+
+	if blocklist.disabledUntil == nil || time.Now().After(*blocklist.disabledUntil) {
+		return false
+	}
+
+	blocklist.disabledUntil = nil
+	blocklist.logger.Info("Blocklist re-enabled")
+	return true
+}
+
+type BlocklistStatus struct {
+	Disabled          bool       `json:"disabled"`
+	Unitl             *time.Time `json:"until,omitempty"`
+	ApproxSize        uint32     `json:"approx_size"`
+	FalsePositiveRate float64    `json:"false_positive_rate"`
+}
+
+// Status returns whether the blocklist is currently disabled and until when
+func (blocklist *BlockList) Status() *BlocklistStatus {
+	blocklist.mutex.RLock()
+	defer blocklist.mutex.RUnlock()
+
+	status := BlocklistStatus{
+		Disabled:          blocklist.disabledUntil != nil && time.Now().Before(*blocklist.disabledUntil),
+		Unitl:             blocklist.disabledUntil,
+		ApproxSize:        blocklist.bloomFilter.ApproximatedSize(),
+		FalsePositiveRate: blocklist.fpRate,
+	}
+
+	return &status
 }
 
 func (blocklist *BlockList) ApplyBloomFilter(bf *bloom.BloomFilter, n uint) {

--- a/internal/blocklist/blocklist_test.go
+++ b/internal/blocklist/blocklist_test.go
@@ -4,40 +4,35 @@ import (
 	"io"
 	"log/slog"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 )
 
-func TestIsBlocked_ApexDomain_PublicSuffix(t *testing.T) {
-	assert := assert.New(t)
+func TestBlocklist_DisableAndIsBlocked(t *testing.T) {
+	// Use a dummy handler that won't panic when passed nil
+	logger := slog.New(slog.NewJSONHandler(io.Discard, nil))
+	// Create a blocklist with one entry
+	blockList := NewBlockList([]string{"example.com"}, 0.0001, logger)
 
-	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
-	blockList := NewBlockList([]string{"host1.com", "host2.com"}, 0.0001, logger)
+	// Initially, example.com should be blocked
+	isBlocked, err := blockList.IsBlocked("example.com")
+	assert.NoError(t, err)
+	assert.True(t, isBlocked, "example.com should be blocked initially")
 
-	isBlocked, err := blockList.IsBlocked("s3.amazonaws.com.")
-	assert.NoError(err)
-	assert.False(isBlocked)
-}
+	// Disable the blocklist for 1 second
+	blockList.Disable(1 * time.Second)
 
-func TestNewBlockList_NilItems(t *testing.T) {
-	assert := assert.New(t)
-	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	// Now example.com should not be blocked (but should log a warning)
+	isBlocked, err = blockList.IsBlocked("example.com")
+	assert.NoError(t, err)
+	assert.False(t, isBlocked, "example.com should not be blocked when disabled")
 
-	// This should not panic when IsBlocked is called
-	blockList := NewBlockList(nil, 0.0001, logger)
+	// Wait for the disable period to expire
+	time.Sleep(2 * time.Second)
 
-	assert.NotPanics(func() {
-		_, _ = blockList.IsBlocked("test.com")
-	})
-}
-
-func TestNewBlockList_EmptyItems(t *testing.T) {
-	assert := assert.New(t)
-	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
-
-	blockList := NewBlockList([]string{}, 0.0001, logger)
-
-	assert.NotPanics(func() {
-		_, _ = blockList.IsBlocked("test.com")
-	})
+	// After the disable period, example.com should be blocked again
+	isBlocked, err = blockList.IsBlocked("example.com")
+	assert.NoError(t, err)
+	assert.True(t, isBlocked, "example.com should be blocked again after disable period expires")
 }

--- a/internal/http/handlers/blocklist.go
+++ b/internal/http/handlers/blocklist.go
@@ -49,6 +49,11 @@ func (h *BlocklistHandler) Disable(c *gin.Context) {
 		}
 	}
 
+	if d <= 0 {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "Duration must be greater than zero"})
+		return
+	}
+
 	disabledUntil := h.updater.Blocklist.Disable(d)
 	c.JSON(http.StatusOK, gin.H{
 		"message":  "Blocklist temporarily disabled",

--- a/internal/http/handlers/blocklist.go
+++ b/internal/http/handlers/blocklist.go
@@ -4,6 +4,7 @@ import (
 	"log/slog"
 	"net/http"
 	"strings"
+	"time"
 
 	"github.com/gin-gonic/gin"
 	"github.com/miekg/dns"
@@ -25,6 +26,47 @@ func (h *BlocklistHandler) Reload(c *gin.Context) {
 		"message": "Blocklist reload triggered",
 		"urls":    h.updater.URLs,
 	})
+}
+
+func (h *BlocklistHandler) Disable(c *gin.Context) {
+	var payload struct {
+		Duration string `json:"duration"`
+	}
+	if err := c.ShouldBindJSON(&payload); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid JSON payload"})
+		return
+	}
+
+	d, err := time.ParseDuration(payload.Duration)
+	if err != nil {
+		// Try ISO 8601 duration
+		if after, ok := strings.CutPrefix(payload.Duration, "PT"); ok {
+			d, err = time.ParseDuration(strings.ToLower(after))
+		}
+		if err != nil {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid duration format"})
+			return
+		}
+	}
+
+	disabledUntil := h.updater.Blocklist.Disable(d)
+	c.JSON(http.StatusOK, gin.H{
+		"message":  "Blocklist temporarily disabled",
+		"duration": d.String(),
+		"until":    disabledUntil,
+	})
+}
+
+func (h *BlocklistHandler) Reenable(c *gin.Context) {
+	if h.updater.Blocklist.Reenable() {
+		c.JSON(http.StatusOK, gin.H{"message": "Blocklist re-enabled"})
+	} else {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "Blocklist is not currently disabled"})
+	}
+}
+
+func (h *BlocklistHandler) Status(c *gin.Context) {
+	c.JSON(http.StatusOK, h.updater.Blocklist.Status())
 }
 
 func (h *BlocklistHandler) Check(c *gin.Context) {

--- a/internal/http/routes/routes.go
+++ b/internal/http/routes/routes.go
@@ -32,8 +32,7 @@ func NewAdminGroup(
 	r *gin.Engine,
 	adminHost string,
 	devMode bool,
-	blocklistCheckHandler gin.HandlerFunc,
-	blocklistReloadHandler gin.HandlerFunc,
+	blocklistHandler *handlers.BlocklistHandler,
 	broadcaster *sse.Broadcaster,
 	geoIp geoblock.GeoIpLookup,
 ) *gin.RouterGroup {
@@ -54,8 +53,11 @@ func NewAdminGroup(
 		api.Use(middlewares.RequireProxyAuth(devMode))
 		{
 			api.OPTIONS("/*path", corsPreflightHandler)
-			api.POST("/blocklist/check", blocklistCheckHandler)
-			api.POST("/blocklist/reload", blocklistReloadHandler)
+			api.POST("/blocklist/check", blocklistHandler.Check)
+			api.POST("/blocklist/reload", blocklistHandler.Reload)
+			api.POST("/blocklist/disable", blocklistHandler.Disable)
+			api.POST("/blocklist/reenable", blocklistHandler.Reenable)
+			api.GET("/blocklist/status", blocklistHandler.Status)
 			api.GET("/asn/:ip", cachecontrol.NewWithOptions(cachecontrol.WithMaxAge(cachecontrol.Duration(24*time.Hour))), asnLookupHandler(geoIp))
 			api.GET("/events", cachecontrol.New(cachecontrol.NoCachePreset), sseHandler(broadcaster))
 			api.GET("/whoami", whoAmIHandler)

--- a/test.http
+++ b/test.http
@@ -36,6 +36,20 @@ google.com
 www.ex.co
 ads.net
 
+### Disable blocklist
+POST http://admin.localhost:8080/api/blocklist/disable
+Content-Type: application/json
+
+{"duration": "PT5M"}
+
+### Re-enable blocklist
+POST http://admin.localhost:8080/api/blocklist/reenable
+Content-Type: application/json
+
+### Blocklist status
+GET http://admin.localhost:8080/api/blocklist/status
+
+
 ### ASN Lookup
 GET http://admin.localhost:8080/api/asn/24.123.12.0
 


### PR DESCRIPTION
Introduced a mechanism to temporarily bypass the blocklist, allowing for
 troubleshooting or maintenance. Added administrative HTTP endpoints to
manage this state and view the current blocklist status.

### Data Flow
```mermaid
sequenceDiagram
    participant User
    participant Handler as BlocklistHandler
    participant BL as BlockList

    User->>Handler: POST /blocklist/disable
    Handler->>BL: Disable(duration)
    BL->>BL: Set disabledUntil timestamp

    Note over User, BL: Subsequent DNS queries check disabledUntil

    User->>Handler: POST /blocklist/reenable
    Handler->>BL: Reenable()
    BL->>BL: Clear disabledUntil
```