### PR TITLE
feat: move blocklist response to authority section

### DIFF
--- a/internal/forwarder/dispatcher.go
+++ b/internal/forwarder/dispatcher.go
@@ -187,7 +187,17 @@ func (d *DNSDispatcher) HandleDNSRequest(source DNSSource) DispatcherFunc {
 			}
 
 			if len(res.extra) > 0 {
-				resp.Extra = append(resp.Extra, res.extra...)
+				for _, rr := range res.extra {
+					if opt, ok := rr.(*dns.OPT); ok {
+						if existingOpt := resp.IsEdns0(); existingOpt != nil {
+							existingOpt.Option = append(existingOpt.Option, opt.Option...)
+						} else {
+							resp.Extra = append(resp.Extra, opt)
+						}
+					} else {
+						resp.Extra = append(resp.Extra, rr)
+					}
+				}
 			}
 
 			if len(res.answer) > 0 {

--- a/internal/forwarder/dispatcher.go
+++ b/internal/forwarder/dispatcher.go
@@ -41,6 +41,7 @@ var (
 
 type RequestContext struct {
 	ctx      context.Context
+	req      *dns.Msg
 	snapshot *metrics.RequestSnapshot
 	logger   *slog.Logger
 	ipAddr   string
@@ -144,6 +145,7 @@ func (d *DNSDispatcher) HandleDNSRequest(source DNSSource) DispatcherFunc {
 
 		requestCtx := &RequestContext{
 			ctx:      ctx,
+			req:      req,
 			logger:   d.logger.With("client_ip", ipAddr, "request_id", req.Id, "source", source),
 			snapshot: metrics.NewRequestSnapshot(time.Now(), string(source), ipAddr),
 			ipAddr:   ipAddr,
@@ -169,7 +171,7 @@ func (d *DNSDispatcher) HandleDNSRequest(source DNSSource) DispatcherFunc {
 		unansweredQuestions := make([]dns.Question, 0, len(req.Question))
 
 		for _, q := range req.Question {
-			answers, rcode, err := d.processQuestion(requestCtx, &q)
+			answers, authority, extra, rcode, err := d.processQuestion(requestCtx, &q)
 			if err != nil {
 				resp.Rcode = dns.RcodeServerFailure
 				d.sendResponse(requestCtx, writer, resp)
@@ -182,9 +184,17 @@ func (d *DNSDispatcher) HandleDNSRequest(source DNSSource) DispatcherFunc {
 				return
 			}
 
+			if len(authority) > 0 {
+				resp.Ns = append(resp.Ns, authority...)
+			}
+
+			if len(extra) > 0 {
+				resp.Extra = append(resp.Extra, extra...)
+			}
+
 			if len(answers) > 0 {
 				resp.Answer = append(resp.Answer, answers...)
-			} else if !isDNSSDQuery(q.Name) {
+			} else if len(authority) == 0 && len(extra) == 0 && !isDNSSDQuery(q.Name) {
 				unansweredQuestions = append(unansweredQuestions, q)
 			}
 		}
@@ -199,9 +209,15 @@ func (d *DNSDispatcher) HandleDNSRequest(source DNSSource) DispatcherFunc {
 			}
 
 			resp.Answer = append(resp.Answer, answers...)
+			if len(resp.Answer) == 0 && len(resp.Ns) > 0 {
+				resp.Rcode = dns.RcodeNameError
+			}
 		}
 
-		if len(resp.Answer) == 0 && len(resp.Ns) > 0 {
+		if len(resp.Answer) == 0 && len(resp.Ns) > 0 && resp.Rcode == dns.RcodeSuccess {
+			// Preserve success for authority-only responses such as blocked-domain SOA replies.
+			// Upstream negative responses are already propagated earlier via resolveUpstream.
+		} else if len(resp.Answer) == 0 && len(resp.Ns) > 0 {
 			resp.Rcode = dns.RcodeNameError
 		}
 
@@ -238,7 +254,10 @@ func (d *DNSDispatcher) snapshotWorker() {
 	}
 }
 
-func (d *DNSDispatcher) processQuestion(requestCtx *RequestContext, q *dns.Question) ([]dns.RR, int, error) {
+func (d *DNSDispatcher) processQuestion(requestCtx *RequestContext, q *dns.Question) (
+	answer []dns.RR, authority []dns.RR, extra []dns.RR, rcode int, err error,
+) {
+
 	tracer := telemetry.GetTracer("dns-dispatcher")
 	_, span := tracer.Start(requestCtx.ctx, "processQuestion",
 		trace.WithAttributes(
@@ -258,7 +277,7 @@ func (d *DNSDispatcher) processQuestion(requestCtx *RequestContext, q *dns.Quest
 		span.RecordError(err)
 		span.SetStatus(codes.Error, err.Error())
 		d.reportError(requestCtx, "blocklist", err, q.Name, "qtype", queryType)
-		return nil, dns.RcodeServerFailure, err
+		return nil, nil, nil, dns.RcodeServerFailure, err
 	}
 
 	if isBlocked {
@@ -274,14 +293,34 @@ func (d *DNSDispatcher) processQuestion(requestCtx *RequestContext, q *dns.Quest
 				Class:  dns.ClassINET,
 				Ttl:    uint32(d.defaultTTL),
 			},
-			Ns:   "ns.blocked.local.",
-			Mbox: "hostmaster.blocked.local.", Serial: 1,
+			Ns:      "ns.blocked.local.",
+			Mbox:    "hostmaster.blocked.local.",
+			Serial:  1,
 			Refresh: 3600,
 			Retry:   900,
 			Expire:  604800,
 			Minttl:  uint32(d.defaultTTL),
 		}
-		return []dns.RR{soa}, dns.RcodeSuccess, nil
+
+		// Inject EDE for blocked domain
+		ede := &dns.EDNS0_EDE{
+			InfoCode:  dns.ExtendedErrorCodeBlocked,
+			ExtraText: fmt.Sprintf("Blocked by policy: %s", q.Name),
+		}
+
+		var extra []dns.RR
+		if optIn := requestCtx.req.IsEdns0(); optIn != nil {
+			o := new(dns.OPT)
+			o.Hdr.Name = "."
+			o.Hdr.Rrtype = dns.TypeOPT
+			o.SetUDPSize(optIn.UDPSize())
+			o.SetVersion(optIn.Version())
+			o.SetDo(optIn.Do())
+			o.Option = append(o.Option, ede)
+			extra = []dns.RR{o}
+		}
+
+		return nil, []dns.RR{soa}, extra, dns.RcodeSuccess, nil
 	}
 
 	if isReservedLocalhost(q.Name) {
@@ -295,18 +334,18 @@ func (d *DNSDispatcher) processQuestion(requestCtx *RequestContext, q *dns.Quest
 			},
 			A: net.ParseIP("127.0.0.1"),
 		}
-		return []dns.RR{a}, dns.RcodeSuccess, nil
+		return []dns.RR{a}, nil, nil, dns.RcodeSuccess, nil
 	}
 
 	if isReservedTLD(q.Name) {
 		requestCtx.logger.DebugContext(requestCtx.ctx, "Blocking reserved TLD", "name", q.Name)
-		return nil, dns.RcodeNameError, nil
+		return nil, nil, nil, dns.RcodeNameError, nil
 	}
 
 	if isDNSSDQuery(q.Name) {
 		requestCtx.logger.DebugContext(requestCtx.ctx, "Short-circuiting DNS-SD query", "name", q.Name)
 		requestCtx.snapshot.AddQueryCount(queryType, false)
-		return nil, dns.RcodeNameError, nil
+		return nil, nil, nil, dns.RcodeNameError, nil
 	}
 
 	requestCtx.snapshot.AddDomain(q.Name)
@@ -314,10 +353,10 @@ func (d *DNSDispatcher) processQuestion(requestCtx *RequestContext, q *dns.Quest
 	if cachedRRs, ok := d.cache.Get(getCacheKey(q, requestCtx.subnet)); ok {
 		span.SetAttributes(attribute.Bool("dns.cache_hit", true))
 		requestCtx.snapshot.SetFromCache(true)
-		return cachedRRs, dns.RcodeSuccess, nil
+		return cachedRRs, nil, nil, dns.RcodeSuccess, nil
 	}
 
-	return nil, dns.RcodeSuccess, nil
+	return nil, nil, nil, dns.RcodeSuccess, nil
 }
 
 func (d *DNSDispatcher) resolveUpstream(requestCtx *RequestContext, unansweredQuestions []dns.Question, req *dns.Msg) (int, []dns.RR, error) {

--- a/internal/forwarder/dispatcher.go
+++ b/internal/forwarder/dispatcher.go
@@ -164,37 +164,35 @@ func (d *DNSDispatcher) HandleDNSRequest(source DNSSource) DispatcherFunc {
 			}
 		}()
 
-		resp := new(dns.Msg)
-		resp.SetReply(req)
-		resp.Question = req.Question
+		resp := d.newReply(req)
 
 		unansweredQuestions := make([]dns.Question, 0, len(req.Question))
 
 		for _, q := range req.Question {
-			answers, authority, extra, rcode, err := d.processQuestion(requestCtx, &q)
+			res, err := d.processQuestion(requestCtx, &q)
 			if err != nil {
 				resp.Rcode = dns.RcodeServerFailure
 				d.sendResponse(requestCtx, writer, resp)
 				return
 			}
 
-			if rcode != dns.RcodeSuccess {
-				resp.Rcode = rcode
+			if res.rcode != dns.RcodeSuccess {
+				resp.Rcode = res.rcode
 				d.sendResponse(requestCtx, writer, resp)
 				return
 			}
 
-			if len(authority) > 0 {
-				resp.Ns = append(resp.Ns, authority...)
+			if len(res.authority) > 0 {
+				resp.Ns = append(resp.Ns, res.authority...)
 			}
 
-			if len(extra) > 0 {
-				resp.Extra = append(resp.Extra, extra...)
+			if len(res.extra) > 0 {
+				resp.Extra = append(resp.Extra, res.extra...)
 			}
 
-			if len(answers) > 0 {
-				resp.Answer = append(resp.Answer, answers...)
-			} else if len(authority) == 0 && len(extra) == 0 && !isDNSSDQuery(q.Name) {
+			if len(res.answer) > 0 {
+				resp.Answer = append(resp.Answer, res.answer...)
+			} else if len(res.authority) == 0 && len(res.extra) == 0 && !isDNSSDQuery(q.Name) {
 				unansweredQuestions = append(unansweredQuestions, q)
 			}
 		}
@@ -223,6 +221,13 @@ func (d *DNSDispatcher) HandleDNSRequest(source DNSSource) DispatcherFunc {
 
 		d.sendResponse(requestCtx, writer, resp)
 	}
+}
+
+func (d *DNSDispatcher) newReply(req *dns.Msg) *dns.Msg {
+	resp := new(dns.Msg)
+	resp.SetReply(req)
+	resp.Question = req.Question
+	return resp
 }
 
 func (d *DNSDispatcher) snapshotWorker() {
@@ -254,9 +259,14 @@ func (d *DNSDispatcher) snapshotWorker() {
 	}
 }
 
-func (d *DNSDispatcher) processQuestion(requestCtx *RequestContext, q *dns.Question) (
-	answer []dns.RR, authority []dns.RR, extra []dns.RR, rcode int, err error,
-) {
+type QuestionResolution struct {
+	answer    []dns.RR
+	authority []dns.RR
+	extra     []dns.RR
+	rcode     int
+}
+
+func (d *DNSDispatcher) processQuestion(requestCtx *RequestContext, q *dns.Question) (QuestionResolution, error) {
 
 	tracer := telemetry.GetTracer("dns-dispatcher")
 	_, span := tracer.Start(requestCtx.ctx, "processQuestion",
@@ -277,50 +287,11 @@ func (d *DNSDispatcher) processQuestion(requestCtx *RequestContext, q *dns.Quest
 		span.RecordError(err)
 		span.SetStatus(codes.Error, err.Error())
 		d.reportError(requestCtx, "blocklist", err, q.Name, "qtype", queryType)
-		return nil, nil, nil, dns.RcodeServerFailure, err
+		return QuestionResolution{rcode: dns.RcodeServerFailure}, err
 	}
 
 	if isBlocked {
-		requestCtx.logger.DebugContext(requestCtx.ctx, "Domain blocked", "name", q.Name)
-		requestCtx.snapshot.AddBlockedDomain(q.Name)
-		requestCtx.snapshot.AddQueryCount(queryType, true)
-		span.SetAttributes(attribute.Bool("dns.blocked", true))
-
-		soa := &dns.SOA{
-			Hdr: dns.RR_Header{
-				Name:   q.Name,
-				Rrtype: dns.TypeSOA,
-				Class:  dns.ClassINET,
-				Ttl:    uint32(d.defaultTTL),
-			},
-			Ns:      "ns.blocked.local.",
-			Mbox:    "hostmaster.blocked.local.",
-			Serial:  1,
-			Refresh: 3600,
-			Retry:   900,
-			Expire:  604800,
-			Minttl:  uint32(d.defaultTTL),
-		}
-
-		// Inject EDE for blocked domain
-		ede := &dns.EDNS0_EDE{
-			InfoCode:  dns.ExtendedErrorCodeBlocked,
-			ExtraText: fmt.Sprintf("Blocked by policy: %s", q.Name),
-		}
-
-		var extra []dns.RR
-		if optIn := requestCtx.req.IsEdns0(); optIn != nil {
-			o := new(dns.OPT)
-			o.Hdr.Name = "."
-			o.Hdr.Rrtype = dns.TypeOPT
-			o.SetUDPSize(optIn.UDPSize())
-			o.SetVersion(optIn.Version())
-			o.SetDo(optIn.Do())
-			o.Option = append(o.Option, ede)
-			extra = []dns.RR{o}
-		}
-
-		return nil, []dns.RR{soa}, extra, dns.RcodeSuccess, nil
+		return d.constructBlockedResponse(requestCtx, q, queryType), nil
 	}
 
 	if isReservedLocalhost(q.Name) {
@@ -334,18 +305,18 @@ func (d *DNSDispatcher) processQuestion(requestCtx *RequestContext, q *dns.Quest
 			},
 			A: net.ParseIP("127.0.0.1"),
 		}
-		return []dns.RR{a}, nil, nil, dns.RcodeSuccess, nil
+		return QuestionResolution{answer: []dns.RR{a}, rcode: dns.RcodeSuccess}, nil
 	}
 
 	if isReservedTLD(q.Name) {
 		requestCtx.logger.DebugContext(requestCtx.ctx, "Blocking reserved TLD", "name", q.Name)
-		return nil, nil, nil, dns.RcodeNameError, nil
+		return QuestionResolution{rcode: dns.RcodeNameError}, nil
 	}
 
 	if isDNSSDQuery(q.Name) {
 		requestCtx.logger.DebugContext(requestCtx.ctx, "Short-circuiting DNS-SD query", "name", q.Name)
 		requestCtx.snapshot.AddQueryCount(queryType, false)
-		return nil, nil, nil, dns.RcodeNameError, nil
+		return QuestionResolution{rcode: dns.RcodeNameError}, nil
 	}
 
 	requestCtx.snapshot.AddDomain(q.Name)
@@ -353,10 +324,52 @@ func (d *DNSDispatcher) processQuestion(requestCtx *RequestContext, q *dns.Quest
 	if cachedRRs, ok := d.cache.Get(getCacheKey(q, requestCtx.subnet)); ok {
 		span.SetAttributes(attribute.Bool("dns.cache_hit", true))
 		requestCtx.snapshot.SetFromCache(true)
-		return cachedRRs, nil, nil, dns.RcodeSuccess, nil
+		return QuestionResolution{answer: cachedRRs, rcode: dns.RcodeSuccess}, nil
 	}
 
-	return nil, nil, nil, dns.RcodeSuccess, nil
+	return QuestionResolution{rcode: dns.RcodeSuccess}, nil
+}
+
+func (d *DNSDispatcher) constructBlockedResponse(requestCtx *RequestContext, q *dns.Question, queryType string) QuestionResolution {
+	requestCtx.logger.DebugContext(requestCtx.ctx, "Domain blocked", "name", q.Name)
+	requestCtx.snapshot.AddBlockedDomain(q.Name)
+	requestCtx.snapshot.AddQueryCount(queryType, true)
+
+	soa := &dns.SOA{
+		Hdr: dns.RR_Header{
+			Name:   q.Name,
+			Rrtype: dns.TypeSOA,
+			Class:  dns.ClassINET,
+			Ttl:    uint32(d.defaultTTL),
+		},
+		Ns:      "ns.blocked.local.",
+		Mbox:    "hostmaster.blocked.local.",
+		Serial:  1,
+		Refresh: 3600,
+		Retry:   900,
+		Expire:  604800,
+		Minttl:  uint32(d.defaultTTL),
+	}
+
+	// Inject EDE for blocked domain
+	ede := &dns.EDNS0_EDE{
+		InfoCode:  dns.ExtendedErrorCodeBlocked,
+		ExtraText: fmt.Sprintf("Blocked by policy: %s", q.Name),
+	}
+
+	var extra []dns.RR
+	if optIn := requestCtx.req.IsEdns0(); optIn != nil {
+		o := new(dns.OPT)
+		o.Hdr.Name = "."
+		o.Hdr.Rrtype = dns.TypeOPT
+		o.SetUDPSize(optIn.UDPSize())
+		o.SetVersion(optIn.Version())
+		o.SetDo(optIn.Do())
+		o.Option = append(o.Option, ede)
+		extra = []dns.RR{o}
+	}
+
+	return QuestionResolution{authority: []dns.RR{soa}, extra: extra, rcode: dns.RcodeSuccess}
 }
 
 func (d *DNSDispatcher) resolveUpstream(requestCtx *RequestContext, unansweredQuestions []dns.Question, req *dns.Msg) (int, []dns.RR, error) {

--- a/internal/forwarder/dispatcher_test.go
+++ b/internal/forwarder/dispatcher_test.go
@@ -153,15 +153,19 @@ func TestDNSDispatcher_HandleDNSRequest_MixedBlockedAndUpstream(t *testing.T) {
 	assert.NotNil(t, writer.WrittenMsg)
 	assert.Equal(t, dns.RcodeSuccess, writer.WrittenMsg.Rcode)
 
-	// Should have 2 answers: google.com A record and ads.0xbt.net SOA record
-	assert.Len(t, writer.WrittenMsg.Answer, 2)
+	// The upstream answer should stay in the answer section, and the blocked domain should be returned as authority data.
+	assert.Len(t, writer.WrittenMsg.Answer, 1, "should have one upstream answer")
+	assert.Len(t, writer.WrittenMsg.Ns, 1, "should have one blocked authority record")
 
 	foundA := false
 	foundSOA := false
 	for _, rr := range writer.WrittenMsg.Answer {
 		if _, ok := rr.(*dns.A); ok {
 			foundA = true
-		} else if _, ok := rr.(*dns.SOA); ok {
+		}
+	}
+	for _, rr := range writer.WrittenMsg.Ns {
+		if _, ok := rr.(*dns.SOA); ok {
 			foundSOA = true
 		}
 	}
@@ -217,12 +221,48 @@ func TestDNSDispatcher_HandleDNSRequest_Blocked(t *testing.T) {
 	// Assert that the response has an RcodeSuccess Rcode
 	assert.NotNil(t, writer.WrittenMsg)
 	assert.Equal(t, dns.RcodeSuccess, writer.WrittenMsg.Rcode)
-	assert.Len(t, writer.WrittenMsg.Answer, 1, "should have one answer")
-	assert.Len(t, writer.WrittenMsg.Ns, 0, "should have no NS record")
+	assert.Len(t, writer.WrittenMsg.Answer, 0, "should have no answers")
+	assert.Len(t, writer.WrittenMsg.Ns, 1, "should have one authority record")
+	assert.Len(t, writer.WrittenMsg.Extra, 0, "should have no OPT record without EDNS")
 
-	soa, ok := writer.WrittenMsg.Answer[0].(*dns.SOA)
-	assert.True(t, ok, "should be a SOA record")
+	soa, ok := writer.WrittenMsg.Ns[0].(*dns.SOA)
+	assert.True(t, ok, "should be a SOA record in the authority section")
 	assert.Equal(t, "ns.blocked.local.", soa.Ns, "unexpected Ns name")
+}
+
+func TestDNSDispatcher_HandleDNSRequest_BlockedIncludesEDE(t *testing.T) {
+	server, upstream := startLocalDNS(t, func(w dns.ResponseWriter, m *dns.Msg) {
+		t.Fail()
+	})
+
+	defer func() {
+		err := server.Shutdown()
+		assert.NoError(t, err)
+	}()
+
+	dispatcher, _, _, _ := setupDispatcherTest(t, upstream, nil, false)
+
+	req := new(dns.Msg)
+	req.SetQuestion("ads.0xbt.net.", dns.TypeA)
+	req.SetEdns0(1232, false)
+
+	writer := new(MockResponseWriter)
+	writer.On("WriteMsg", mock.Anything).Return(nil)
+
+	dispatcher.HandleDNSRequest("test")(writer, req)
+
+	require.NotNil(t, writer.WrittenMsg)
+	require.Len(t, writer.WrittenMsg.Ns, 1)
+	require.Len(t, writer.WrittenMsg.Extra, 1)
+
+	opt, ok := writer.WrittenMsg.Extra[0].(*dns.OPT)
+	require.True(t, ok, "expected an OPT record to carry EDE")
+	require.Len(t, opt.Option, 1)
+
+	ede, ok := opt.Option[0].(*dns.EDNS0_EDE)
+	require.True(t, ok, "expected EDE option")
+	assert.Equal(t, dns.ExtendedErrorCodeBlocked, ede.InfoCode)
+	assert.Contains(t, ede.ExtraText, "Blocked by policy")
 }
 
 func TestDNSDispatcher_HandleDNSRequest_MultipleQuestions(t *testing.T) {
@@ -250,12 +290,13 @@ func TestDNSDispatcher_HandleDNSRequest_MultipleQuestions(t *testing.T) {
 	// Assert that the response writer was called with a non-nil message
 	assert.NotNil(t, writer.WrittenMsg)
 	assert.Equal(t, dns.RcodeSuccess, writer.WrittenMsg.Rcode)
-	assert.Len(t, writer.WrittenMsg.Answer, 2)
+	assert.Len(t, writer.WrittenMsg.Answer, 1)
+	assert.Len(t, writer.WrittenMsg.Ns, 1)
 	assert.Len(t, writer.WrittenMsg.Question, 2)
 
-	// Verify that the blocked domain has a SOA record in the answer section
+	// Verify that the blocked domain has a SOA record in the authority section
 	foundSOA := false
-	for _, rr := range writer.WrittenMsg.Answer {
+	for _, rr := range writer.WrittenMsg.Ns {
 		if soa, ok := rr.(*dns.SOA); ok {
 			if soa.Hdr.Name == "ads.0xbt.net." {
 				assert.Equal(t, "ns.blocked.local.", soa.Ns, "unexpected Ns name for blocked domain")
@@ -264,7 +305,7 @@ func TestDNSDispatcher_HandleDNSRequest_MultipleQuestions(t *testing.T) {
 			}
 		}
 	}
-	assert.True(t, foundSOA, "SOA record for ads.0xbt.net. not found in answers")
+	assert.True(t, foundSOA, "SOA record for ads.0xbt.net. not found in authority section")
 }
 
 func TestDNSDispatcher_HandleDNSRequest_CacheHit(t *testing.T) {

--- a/internal/integration_test.go
+++ b/internal/integration_test.go
@@ -221,8 +221,8 @@ func TestIntegration_DNSFunctionality(t *testing.T) {
 			if tt.expectBlocked {
 				// Based on internal/forwarder/dispatcher.go, blocked domains return a SOA record with ns.blocked.local.
 				foundBlockedSOA := false
-				for _, ans := range resp.Answer {
-					if soa, ok := ans.(*dns.SOA); ok {
+				for _, rr := range append(resp.Answer, resp.Ns...) {
+					if soa, ok := rr.(*dns.SOA); ok {
 						if soa.Ns == "ns.blocked.local." {
 							foundBlockedSOA = true
 							break


### PR DESCRIPTION
- Move blocked domain SOA records from the `Answer` section to the `Authority` section to align with DNS standards.
- Add `EDNS0_EDE` (Extended DNS Error) to the `Extra` section for blocked queries to provide better diagnostic feedback.
- Update multi-question response handling to preserve upstream answers while correctly categorizing blocked domains.

```mermaid
sequenceDiagram
    participant C as Client
    participant D as Dispatcher
    participant B as Blocklist Engine

    C->>D: DNS Query
    D->>B: Check domain
    B-->>D: Is Blocked
    D->>D: Construct SOA (Authority)
    D->>D: Construct EDE (Extra)
    D-->>C: Response (Rcode: Success, Ns: [SOA], Extra: [EDE])
```