### PR TITLE
feat: support multiple (distinct) blocklists rather than merging

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,8 +156,11 @@ If `--metrics-auth` is configured, the `/metrics` endpoint is protected by basic
 
 While the public endpoints are available on the main domain, the management APIs are hosted on the admin subdomain (e.g., `admin.dot.your-domain.com`):
 
-- `POST /api/blocklist/reload`: Triggers an asynchronous reload of the blocklists.
-- `POST /api/blocklist/check`: Checks whether provided domains are blocked. Accepts a JSON array of strings or a newline-separated list of domains in the request body.
+- `POST /api/blocklist/reload`: Triggers an asynchronous reload of all configured blocklists.
+- `GET /api/blocklist/status`: Returns the current status of all blocklists, including metadata, record counts, and enabled status.
+- `POST /api/blocklist/disable`: Temporarily disables one or all blocklists. Requires a JSON payload: `{"name": "...", "duration": "1h"}`.
+- `POST /api/blocklist/reenable`: Re-enables all blocklists.
+- `POST /api/blocklist/check`: Checks whether provided domains are blocked against any of the enabled blocklists. Accepts a JSON array of strings or a newline-separated list of domains in the request body.
 - `GET /api/whoami`: Returns information about the currently authenticated user.
 - `GET /api/events`: Streams live DNS requests via Server-Sent Events (SSE). Each event is a JSON object containing the queried domain, client IP, source (UDP/TCP/DoT/DoH), whether it was blocked, and GeoIP data (ASN and Country ISO code).
 
@@ -224,7 +227,7 @@ DoT Block can be configured using the following command-line flags:
 | Flag | Description | Default |
 | :--- | :--- | :--- |
 | `--allowed-hosts` | List of domains used for the CertManager allow policy. | `nil` |
-| `--blocklist-url` | List of URL blocklists (wildcard hostname format). | `https://codeberg.org/hagezi/mirror2/raw/branch/main/dns-blocklists/hosts/pro.txt`, `https://raw.githubusercontent.com/rm-hull/dot-block/refs/heads/main/data/blocklist.txt` |
+| `--blocklist-url` | List of URLs to fetch blocklists from (comma-separated). Each list is managed independently for granular control. | `https://codeberg.org/hagezi/mirror2/raw/branch/main/dns-blocklists/hosts/pro.txt` |
 | `--noise-filter-url` | URL of noise filter (CSV format: category,rcode,domain_suffix). | `https://raw.githubusercontent.com/rm-hull/dot-block/refs/heads/main/data/noise-filter.txt` |
 | `--cache-ttl-floor` | Minimum TTL for cached entries (in seconds). If a response is not "freshness sensitive" (e.g. contains `ocsp`, `crl`, `pki` or is `SOA`/`TXT`), the cache TTL will be at least this value. | `3600s` |
 | `--dial-timeout` | Timeout for establishing TCP connections to upstream servers | `300ms` |

--- a/data/blocklist.txt
+++ b/data/blocklist.txt
@@ -1,4 +1,4 @@
-# dot-block custom blocklist
+# Title: dot-block custom blocklist
 # Last modified: 19 July 2026 01:15 BST
 # Notes: raise an issue/create a PR to add/remove entries from this blocklist
 #

--- a/internal/app.go
+++ b/internal/app.go
@@ -461,12 +461,12 @@ func (app *App) NewBlockLists(crontab *cron.Cron) ([]blocklist.BlockList, *block
 	blockLists := make([]blocklist.BlockList, 0)
 	for idx, url := range app.BlockListURLs {
 		blockList := blocklist.NewBlockList(fmt.Sprintf("Blocklist #%d", idx), url, 0.0001, app.Logger)
-		if err := blockList.LoadFromURL(); err != nil {
+		if err := blockList.Fetch(); err != nil {
 			return nil, nil, errors.Wrapf(err, "failed to load blocklist: %s", url)
 		}
 		blockLists = append(blockLists, *blockList)
 	}
-	
+
 	app.Logger.Info("Creating blocklist downloader cron job", "schedule", app.CronSchedule.Downloader)
 	updater := blocklist.NewUpdater(blockLists)
 	if _, err := crontab.AddJob(app.CronSchedule.Downloader, updater); err != nil {

--- a/internal/app.go
+++ b/internal/app.go
@@ -457,14 +457,14 @@ func (app *App) initMaxmind(crontab *cron.Cron) (geoblock.GeoIpLookup, error) {
 	return geoIpLookup, nil
 }
 
-func (app *App) NewBlockLists(crontab *cron.Cron) ([]blocklist.BlockList, *blocklist.Updater, error) {
-	blockLists := make([]blocklist.BlockList, 0)
+func (app *App) NewBlockLists(crontab *cron.Cron) ([]*blocklist.BlockList, *blocklist.Updater, error) {
+	blockLists := make([]*blocklist.BlockList, 0)
 	for idx, url := range app.BlockListURLs {
 		blockList := blocklist.NewBlockList(fmt.Sprintf("Blocklist #%d", idx), url, 0.0001, app.Logger)
 		if err := blockList.Fetch(); err != nil {
 			return nil, nil, errors.Wrapf(err, "failed to load blocklist: %s", url)
 		}
-		blockLists = append(blockLists, *blockList)
+		blockLists = append(blockLists, blockList)
 	}
 
 	app.Logger.Info("Creating blocklist downloader cron job", "schedule", app.CronSchedule.Downloader)

--- a/internal/app.go
+++ b/internal/app.go
@@ -461,9 +461,6 @@ func (app *App) NewBlockLists(crontab *cron.Cron) ([]*blocklist.BlockList, *bloc
 	blockLists := make([]*blocklist.BlockList, 0)
 	for idx, url := range app.BlockListURLs {
 		blockList := blocklist.NewBlockList(fmt.Sprintf("Blocklist #%d", idx), url, 0.0001, app.Logger)
-		if err := blockList.Fetch(); err != nil {
-			return nil, nil, errors.Wrapf(err, "failed to load blocklist: %s", url)
-		}
 		blockLists = append(blockLists, blockList)
 	}
 
@@ -472,6 +469,7 @@ func (app *App) NewBlockLists(crontab *cron.Cron) ([]*blocklist.BlockList, *bloc
 	if _, err := crontab.AddJob(app.CronSchedule.Downloader, updater); err != nil {
 		return nil, nil, errors.Wrap(err, "failed to create blocklist downloader cron job")
 	}
+	updater.Run()
 
 	return blockLists, updater, nil
 }

--- a/internal/app.go
+++ b/internal/app.go
@@ -164,14 +164,9 @@ func (app *App) RunServer(ctx context.Context) error {
 			return errors.Wrap(err, "failed to initialize GeoData database")
 		}
 	}
-	blockList := blocklist.NewBlockList("combined", nil, 0.0001, app.Logger)
-	if err := blocklist.LoadFromURLs(blockList, app.BlockListURLs); err != nil {
-		return errors.Wrap(err, "failed to load blocklists")
-	}
-	app.Logger.Info("Creating blocklist downloader cron job", "schedule", app.CronSchedule.Downloader)
-	blocklistUpdater := blocklist.NewBlocklistUpdater(blockList, app.BlockListURLs)
-	if _, err = crontab.AddJob(app.CronSchedule.Downloader, blocklistUpdater); err != nil {
-		return errors.Wrap(err, "failed to create blocklist downloader cron job")
+	blockLists, blocklistUpdater, err := app.NewBlockLists(crontab)
+	if err != nil {
+		return errors.Wrap(err, "failed to create blocklist(s)")
 	}
 
 	noiseFilter := noisefilter.NewNoiseFilter()
@@ -224,7 +219,7 @@ func (app *App) RunServer(ctx context.Context) error {
 	}
 
 	broadcaster := sse.NewBroadcaster(app.Logger)
-	dispatcher, err := forwarder.NewDNSDispatcher(cache, metrics, dnsClient, blockList, noiseFilter, broadcaster, app.CacheTtlFloor, app.Logger, app.EnableECS)
+	dispatcher, err := forwarder.NewDNSDispatcher(cache, metrics, dnsClient, blockLists, noiseFilter, broadcaster, app.CacheTtlFloor, app.Logger, app.EnableECS)
 	if err != nil {
 		return errors.Wrap(err, "failed to create dispatcher")
 	}
@@ -367,7 +362,7 @@ func (app *App) newProxyListener(base net.Listener) (*proxyproto.Listener, error
 
 func (app *App) startHttpServer(
 	dnsClient *forwarder.RoundRobinClient,
-	blocklistUpdater *blocklist.BlocklistUpdater,
+	blocklistUpdater *blocklist.Updater,
 	dispatcher *forwarder.DNSDispatcher,
 	geoIpLookup geoblock.GeoIpLookup,
 ) (*gin.Engine, error) {
@@ -460,4 +455,23 @@ func (app *App) initMaxmind(crontab *cron.Cron) (geoblock.GeoIpLookup, error) {
 		return nil, errors.Wrap(err, "failed to create ipinfo.io updater cron job")
 	}
 	return geoIpLookup, nil
+}
+
+func (app *App) NewBlockLists(crontab *cron.Cron) ([]blocklist.BlockList, *blocklist.Updater, error) {
+	blockLists := make([]blocklist.BlockList, 0)
+	for idx, url := range app.BlockListURLs {
+		blockList := blocklist.NewBlockList(fmt.Sprintf("Blocklist #%d", idx), url, 0.0001, app.Logger)
+		if err := blockList.LoadFromURL(); err != nil {
+			return nil, nil, errors.Wrapf(err, "failed to load blocklist: %s", url)
+		}
+		blockLists = append(blockLists, *blockList)
+	}
+	
+	app.Logger.Info("Creating blocklist downloader cron job", "schedule", app.CronSchedule.Downloader)
+	updater := blocklist.NewUpdater(blockLists)
+	if _, err := crontab.AddJob(app.CronSchedule.Downloader, updater); err != nil {
+		return nil, nil, errors.Wrap(err, "failed to create blocklist downloader cron job")
+	}
+
+	return blockLists, updater, nil
 }

--- a/internal/blocklist/blocklist.go
+++ b/internal/blocklist/blocklist.go
@@ -29,6 +29,15 @@ type BlockList struct {
 	disabledUntil   *time.Time
 }
 
+type BlocklistStatus struct {
+	URL               string            `json:"url"`
+	Size              uint              `json:"size"`
+	MetaData          map[string]string `json:"metadata,omitempty"`
+	LastUpdated       *time.Time        `json:"last_updated,omitempty"`
+	DisabledUntil     *time.Time        `json:"disabled_until,omitempty"`
+	FalsePositiveRate float64           `json:"estimated_false_positive_rate"`
+}
+
 func NewBlockList(name string, url string, fpRate float64, logger *slog.Logger) *BlockList {
 	metrics, _ := metrics.NewBlockListMetrics()
 
@@ -59,6 +68,11 @@ func (blockList *BlockList) IsBlocked(fqdn string) (bool, error) {
 
 	blockList.mutex.RLock()
 	defer blockList.mutex.RUnlock()
+
+	// Check whether blocklist was initializaed first
+	if blockList.bloomFilter == nil {
+		return false, nil
+	}
 
 	isBlocked := blockList.bloomFilter.TestString(domain)
 
@@ -116,15 +130,6 @@ func (blocklist *BlockList) Reenable() bool {
 	blocklist.disabledUntil = nil
 	blocklist.logger.Info("Blocklist re-enabled", "name", blocklist.name)
 	return true
-}
-
-type BlocklistStatus struct {
-	URL               string            `json:"url"`
-	Size              uint              `json:"size"`
-	MetaData          map[string]string `json:"metadata,omitempty"`
-	LastUpdated       *time.Time        `json:"last_updated,omitempty"`
-	DisabledUntil     *time.Time        `json:"disabled_until,omitempty"`
-	FalsePositiveRate float64           `json:"estimated_false_positive_rate"`
 }
 
 func (blocklist *BlockList) Status() *BlocklistStatus {

--- a/internal/blocklist/blocklist.go
+++ b/internal/blocklist/blocklist.go
@@ -2,17 +2,21 @@ package blocklist
 
 import (
 	"log/slog"
+	"os"
 	"strings"
 	"sync"
 	"time"
 
 	"github.com/bits-and-blooms/bloom/v3"
+	"github.com/cockroachdb/errors"
+	"github.com/rm-hull/dot-block/internal/downloader"
 	"github.com/rm-hull/dot-block/internal/metrics"
 	"golang.org/x/net/publicsuffix"
 )
 
 type BlockList struct {
 	name          string
+	url           string
 	fpRate        float64
 	bloomFilter   *bloom.BloomFilter
 	metrics       *metrics.BlockListMetrics
@@ -21,23 +25,27 @@ type BlockList struct {
 	disabledUntil *time.Time
 }
 
-func NewBlockList(name string, items []string, fpRate float64, logger *slog.Logger) *BlockList {
+func NewBlockList(name string, url string, fpRate float64, logger *slog.Logger) *BlockList {
 	metrics, _ := metrics.NewBlockListMetrics()
 
 	blocklist := &BlockList{
 		name:    name,
+		url:     url,
 		fpRate:  fpRate,
 		metrics: metrics,
 		logger:  logger,
 		mutex:   &sync.RWMutex{},
 	}
 
-	blocklist.Load(items)
 	return blocklist
 }
 
 func (BlockList *BlockList) Name() string {
 	return BlockList.name
+}
+
+func (blockList *BlockList) URL() string {
+	return blockList.url
 }
 
 // Returns whether the URL (or part of the URL) is on a block list.
@@ -145,4 +153,35 @@ func (blocklist *BlockList) ApplyBloomFilter(bf *bloom.BloomFilter, n uint) {
 	blocklist.mutex.Unlock()
 
 	blocklist.metrics.Update(n)
+}
+
+func (bl *BlockList) LoadFromURL() error {
+	path, _, isTemp, err := downloader.Download(bl.logger, "", "blocklist", bl.url, "")
+	if err != nil {
+		return errors.Wrapf(err, "failed to download blocklist for counting: %s", bl.url)
+	}
+
+	defer func() {
+		if isTemp {
+			_ = os.Remove(path)
+		}
+	}()
+
+	count, err := countFromFile(path, bl.logger)
+	if err != nil {
+		return errors.Wrapf(err, "failed to count hosts in file %s (url: %s)", path, bl.url)
+	}
+
+	// Avoid creating a bloom filter with 0 items, which will panic
+	if count == 0 {
+		count = 1
+	}
+
+	bf := bloom.NewWithEstimates(count, bl.fpRate)
+	if err := streamFromFile(path, bl.logger, func(host string) { bf.AddString(host) }); err != nil {
+		return errors.Wrapf(err, "failed to stream hosts from file %s (url: %s)", path, bl.url)
+	}
+
+	bl.ApplyBloomFilter(bf, count)
+	return nil
 }

--- a/internal/blocklist/blocklist.go
+++ b/internal/blocklist/blocklist.go
@@ -155,7 +155,7 @@ func (blocklist *BlockList) ApplyBloomFilter(bf *bloom.BloomFilter, n uint) {
 	blocklist.metrics.Update(n)
 }
 
-func (bl *BlockList) LoadFromURL() error {
+func (bl *BlockList) Fetch() error {
 	path, _, isTemp, err := downloader.Download(bl.logger, "", "blocklist", bl.url, "")
 	if err != nil {
 		return errors.Wrapf(err, "failed to download blocklist for counting: %s", bl.url)

--- a/internal/blocklist/blocklist.go
+++ b/internal/blocklist/blocklist.go
@@ -202,7 +202,7 @@ func (blockList *BlockList) Fetch() error {
 
 	metadata, err := extractMetadata(path)
 	if err != nil {
-		return errors.Wrapf(err, "failed to stream hosts from file %s (url: %s)", path, blockList.url)
+		return errors.Wrapf(err, "failed to extract metadata from file %s (url: %s)", path, blockList.url)
 	}
 
 	blockList.applyBloomFilter(bloomFilter, count, metadata)

--- a/internal/blocklist/blocklist.go
+++ b/internal/blocklist/blocklist.go
@@ -17,6 +17,7 @@ import (
 type BlockList struct {
 	name          string
 	url           string
+	lastUpdated   *time.Time
 	fpRate        float64
 	bloomFilter   *bloom.BloomFilter
 	metrics       *metrics.BlockListMetrics
@@ -86,19 +87,19 @@ func (blocklist *BlockList) Load(items []string) {
 		bf.AddString(item)
 	}
 
-	blocklist.ApplyBloomFilter(bf, n)
+	blocklist.applyBloomFilter(bf, n)
 }
 
 func (blocklist *BlockList) Disable(duration time.Duration) time.Time {
-	t := time.Now().Add(duration)
 	blocklist.mutex.Lock()
-	blocklist.disabledUntil = &t
-	blocklist.mutex.Unlock()
+	defer blocklist.mutex.Unlock()
+
+	blocklist.disabledUntil = new(time.Now().Add(duration))
 	blocklist.logger.Warn("Blocklist temporarily disabled",
 		"name", blocklist.name,
-		"until", t)
+		"until", blocklist.disabledUntil)
 
-	return t
+	return *blocklist.disabledUntil
 }
 
 func (blocklist *BlockList) Reenable() bool {
@@ -115,8 +116,9 @@ func (blocklist *BlockList) Reenable() bool {
 }
 
 type BlocklistStatus struct {
-	Disabled          bool       `json:"disabled"`
-	Until             *time.Time `json:"until,omitempty"`
+	URL               string     `json:"url"`
+	LastUpdated       *time.Time `json:"last_updated,omitempty"`
+	DisabledUntil     *time.Time `json:"disabled_until,omitempty"`
 	ApproxSize        uint32     `json:"approx_size"`
 	FalsePositiveRate float64    `json:"false_positive_rate"`
 }
@@ -126,14 +128,14 @@ func (blocklist *BlockList) Status() *BlocklistStatus {
 	blocklist.mutex.RLock()
 	defer blocklist.mutex.RUnlock()
 
-	var until *time.Time
-	disabled := blocklist.disabledUntil != nil && time.Now().Before(*blocklist.disabledUntil)
-	if disabled {
-		until = blocklist.disabledUntil
+	var disabledUntil *time.Time
+	if blocklist.disabledUntil != nil && time.Now().Before(*blocklist.disabledUntil) {
+		disabledUntil = blocklist.disabledUntil
 	}
 	status := BlocklistStatus{
-		Disabled:          disabled,
-		Until:             until,
+		URL:               blocklist.url,
+		LastUpdated:       blocklist.lastUpdated,
+		DisabledUntil:     disabledUntil,
 		ApproxSize:        blocklist.bloomFilter.ApproximatedSize(),
 		FalsePositiveRate: blocklist.fpRate,
 	}
@@ -141,7 +143,7 @@ func (blocklist *BlockList) Status() *BlocklistStatus {
 	return &status
 }
 
-func (blocklist *BlockList) ApplyBloomFilter(bf *bloom.BloomFilter, n uint) {
+func (blocklist *BlockList) applyBloomFilter(bf *bloom.BloomFilter, n uint) {
 	m, k := bloom.EstimateParameters(n, blocklist.fpRate)
 	blocklist.logger.Info("Bloom filter created",
 		"name", blocklist.name,
@@ -150,15 +152,16 @@ func (blocklist *BlockList) ApplyBloomFilter(bf *bloom.BloomFilter, n uint) {
 
 	blocklist.mutex.Lock()
 	blocklist.bloomFilter = bf
+	blocklist.lastUpdated = new(time.Now())
 	blocklist.mutex.Unlock()
 
 	blocklist.metrics.Update(n)
 }
 
-func (bl *BlockList) Fetch() error {
-	path, _, isTemp, err := downloader.Download(bl.logger, "", "blocklist", bl.url, "")
+func (blockList *BlockList) Fetch() error {
+	path, _, isTemp, err := downloader.Download(blockList.logger, "", "blocklist", blockList.url, "")
 	if err != nil {
-		return errors.Wrapf(err, "failed to download blocklist for counting: %s", bl.url)
+		return errors.Wrapf(err, "failed to download blocklist for counting: %s", blockList.url)
 	}
 
 	defer func() {
@@ -167,9 +170,9 @@ func (bl *BlockList) Fetch() error {
 		}
 	}()
 
-	count, err := countFromFile(path, bl.logger)
+	count, err := countFromFile(path)
 	if err != nil {
-		return errors.Wrapf(err, "failed to count hosts in file %s (url: %s)", path, bl.url)
+		return errors.Wrapf(err, "failed to count hosts in file %s (url: %s)", path, blockList.url)
 	}
 
 	// Avoid creating a bloom filter with 0 items, which will panic
@@ -177,11 +180,16 @@ func (bl *BlockList) Fetch() error {
 		count = 1
 	}
 
-	bf := bloom.NewWithEstimates(count, bl.fpRate)
-	if err := streamFromFile(path, bl.logger, func(host string) { bf.AddString(host) }); err != nil {
-		return errors.Wrapf(err, "failed to stream hosts from file %s (url: %s)", path, bl.url)
+	bloomFilter := bloom.NewWithEstimates(count, blockList.fpRate)
+	scannerFunc := func(host string) bool {
+		bloomFilter.AddString(host)
+		return false
 	}
 
-	bl.ApplyBloomFilter(bf, count)
+	if err := streamFromFile(path, blockList.logger, scannerFunc); err != nil {
+		return errors.Wrapf(err, "failed to stream hosts from file %s (url: %s)", path, blockList.url)
+	}
+
+	blockList.applyBloomFilter(bloomFilter, count)
 	return nil
 }

--- a/internal/blocklist/blocklist.go
+++ b/internal/blocklist/blocklist.go
@@ -15,27 +15,30 @@ import (
 )
 
 type BlockList struct {
-	name          string
-	url           string
-	lastUpdated   *time.Time
-	fpRate        float64
-	bloomFilter   *bloom.BloomFilter
-	metrics       *metrics.BlockListMetrics
-	logger        *slog.Logger
-	mutex         *sync.RWMutex
-	disabledUntil *time.Time
+	name            string
+	url             string
+	metadata        map[string]string
+	lastUpdated     *time.Time
+	minFpRate       float64
+	estimatedFpRate float64
+	bloomFilter     *bloom.BloomFilter
+	size            uint
+	metrics         *metrics.BlockListMetrics
+	logger          *slog.Logger
+	mutex           *sync.RWMutex
+	disabledUntil   *time.Time
 }
 
 func NewBlockList(name string, url string, fpRate float64, logger *slog.Logger) *BlockList {
 	metrics, _ := metrics.NewBlockListMetrics()
 
 	blocklist := &BlockList{
-		name:    name,
-		url:     url,
-		fpRate:  fpRate,
-		metrics: metrics,
-		logger:  logger,
-		mutex:   &sync.RWMutex{},
+		name:      name,
+		url:       url,
+		minFpRate: fpRate,
+		metrics:   metrics,
+		logger:    logger,
+		mutex:     &sync.RWMutex{},
 	}
 
 	return blocklist
@@ -82,12 +85,12 @@ func (blockList *BlockList) IsBlocked(fqdn string) (bool, error) {
 
 func (blocklist *BlockList) Load(items []string) {
 	n := uint(len(items))
-	bf := bloom.NewWithEstimates(n, blocklist.fpRate)
+	bf := bloom.NewWithEstimates(n, blocklist.minFpRate)
 	for _, item := range items {
 		bf.AddString(item)
 	}
 
-	blocklist.applyBloomFilter(bf, n)
+	blocklist.applyBloomFilter(bf, n, nil)
 }
 
 func (blocklist *BlockList) Disable(duration time.Duration) time.Time {
@@ -116,14 +119,14 @@ func (blocklist *BlockList) Reenable() bool {
 }
 
 type BlocklistStatus struct {
-	URL               string     `json:"url"`
-	LastUpdated       *time.Time `json:"last_updated,omitempty"`
-	DisabledUntil     *time.Time `json:"disabled_until,omitempty"`
-	ApproxSize        uint32     `json:"approx_size"`
-	FalsePositiveRate float64    `json:"false_positive_rate"`
+	URL               string            `json:"url"`
+	Size              uint              `json:"size"`
+	MetaData          map[string]string `json:"metadata,omitempty"`
+	LastUpdated       *time.Time        `json:"last_updated,omitempty"`
+	DisabledUntil     *time.Time        `json:"disabled_until,omitempty"`
+	FalsePositiveRate float64           `json:"estimated_false_positive_rate"`
 }
 
-// Status returns whether the blocklist is currently disabled and until when
 func (blocklist *BlockList) Status() *BlocklistStatus {
 	blocklist.mutex.RLock()
 	defer blocklist.mutex.RUnlock()
@@ -134,26 +137,33 @@ func (blocklist *BlockList) Status() *BlocklistStatus {
 	}
 	status := BlocklistStatus{
 		URL:               blocklist.url,
+		Size:              blocklist.size,
+		MetaData:          blocklist.metadata,
 		LastUpdated:       blocklist.lastUpdated,
 		DisabledUntil:     disabledUntil,
-		ApproxSize:        blocklist.bloomFilter.ApproximatedSize(),
-		FalsePositiveRate: blocklist.fpRate,
+		FalsePositiveRate: blocklist.estimatedFpRate,
 	}
 
 	return &status
 }
 
-func (blocklist *BlockList) applyBloomFilter(bf *bloom.BloomFilter, n uint) {
-	m, k := bloom.EstimateParameters(n, blocklist.fpRate)
-	blocklist.logger.Info("Bloom filter created",
-		"name", blocklist.name,
-		"actual_fp_rate", bloom.EstimateFalsePositiveRate(m, k, n),
-		"approx_size", bf.ApproximatedSize())
+func (blocklist *BlockList) applyBloomFilter(bf *bloom.BloomFilter, n uint, metadata map[string]string) {
+	m, k := bloom.EstimateParameters(n, blocklist.minFpRate)
+	estimatedFpRate := bloom.EstimateFalsePositiveRate(m, k, n)
 
 	blocklist.mutex.Lock()
 	blocklist.bloomFilter = bf
+	blocklist.size = n
+	blocklist.metadata = metadata
 	blocklist.lastUpdated = new(time.Now())
+	blocklist.estimatedFpRate = estimatedFpRate
 	blocklist.mutex.Unlock()
+
+	blocklist.logger.Info("Bloom filter created",
+		"name", blocklist.name,
+		"actual_size", n,
+		"estimated_size", bf.ApproximatedSize(),
+		"estimated_fp_rate", estimatedFpRate)
 
 	blocklist.metrics.Update(n)
 }
@@ -180,7 +190,7 @@ func (blockList *BlockList) Fetch() error {
 		count = 1
 	}
 
-	bloomFilter := bloom.NewWithEstimates(count, blockList.fpRate)
+	bloomFilter := bloom.NewWithEstimates(count, blockList.minFpRate)
 	scannerFunc := func(host string) bool {
 		bloomFilter.AddString(host)
 		return false
@@ -190,6 +200,11 @@ func (blockList *BlockList) Fetch() error {
 		return errors.Wrapf(err, "failed to stream hosts from file %s (url: %s)", path, blockList.url)
 	}
 
-	blockList.applyBloomFilter(bloomFilter, count)
+	metadata, err := extractMetadata(path)
+	if err != nil {
+		return errors.Wrapf(err, "failed to stream hosts from file %s (url: %s)", path, blockList.url)
+	}
+
+	blockList.applyBloomFilter(bloomFilter, count, metadata)
 	return nil
 }

--- a/internal/blocklist/blocklist_test.go
+++ b/internal/blocklist/blocklist_test.go
@@ -13,7 +13,8 @@ func TestBlocklist_DisableAndIsBlocked(t *testing.T) {
 	// Use a dummy handler that won't panic when passed nil
 	logger := slog.New(slog.NewJSONHandler(io.Discard, nil))
 	// Create a blocklist with one entry
-	blockList := NewBlockList("test", []string{"example.com"}, 0.0001, logger)
+	blockList := NewBlockList("test", "http://dummy_url", 0.0001, logger)
+	blockList.Load([]string{"example.com"})
 
 	// Initially, example.com should be blocked
 	isBlocked, err := blockList.IsBlocked("example.com")

--- a/internal/blocklist/loader.go
+++ b/internal/blocklist/loader.go
@@ -11,11 +11,13 @@ import (
 
 var prefixes = []string{"0.0.0.0 ", "*.", "www."}
 
-func scanBlocklist(file *os.File, logger *slog.Logger, handler func(string)) error {
+type ScannerFunc func(string) bool
+
+func scanBlocklist(file *os.File, logger *slog.Logger, handler ScannerFunc) error {
 	scanner := bufio.NewScanner(file)
 	for scanner.Scan() {
 		line := strings.TrimSpace(scanner.Text())
-		if strings.HasPrefix(line, "# ") {
+		if strings.HasPrefix(line, "# ") && logger != nil {
 			logger.Info("Blocklist", "comment", line)
 		} else if len(strings.Trim(line, "# ")) == 0 || strings.HasPrefix(line, "## ") {
 			continue // ignore double-octothorpe and empty comments
@@ -25,26 +27,29 @@ func scanBlocklist(file *os.File, logger *slog.Logger, handler func(string)) err
 					line = after
 				}
 			}
-			handler(line)
+			if handler(line) { // finish early?
+				break
+			}
 		}
 	}
 	return scanner.Err()
 }
 
-func countFromFile(path string, logger *slog.Logger) (uint, error) {
+func countFromFile(path string) (uint, error) {
 	var count uint
 	file, err := os.Open(path)
 	if err != nil {
 		return 0, errors.Wrap(err, "failed to open blocklist file for counting")
 	}
 	defer func() { _ = file.Close() }()
-	err = scanBlocklist(file, logger, func(_ string) {
+	err = scanBlocklist(file, nil, func(_ string) bool {
 		count++
+		return false
 	})
 	return count, err
 }
 
-func streamFromFile(path string, logger *slog.Logger, handler func(string)) error {
+func streamFromFile(path string, logger *slog.Logger, handler ScannerFunc) error {
 	file, err := os.Open(path)
 	if err != nil {
 		return errors.Wrap(err, "failed to open blocklist file for streaming")
@@ -52,9 +57,3 @@ func streamFromFile(path string, logger *slog.Logger, handler func(string)) erro
 	defer func() { _ = file.Close() }()
 	return scanBlocklist(file, logger, handler)
 }
-
-// func streamHosts(url string, logger *slog.Logger, handler func(string)) error {
-// 	return downloader.TransientDownload(logger, "", "blocklist-stream", url, "", func(tmpFile string, header http.Header) error {
-// 		return streamFromFile(tmpFile, logger, handler)
-// 	})
-// }

--- a/internal/blocklist/loader.go
+++ b/internal/blocklist/loader.go
@@ -4,11 +4,11 @@ import (
 	"bufio"
 	"log/slog"
 	"os"
+	"regexp"
 	"strings"
-
-	"github.com/cockroachdb/errors"
 )
 
+var nonAlphanumeric = regexp.MustCompile(`[^a-z0-9]+`)
 var prefixes = []string{"0.0.0.0 ", "*.", "www."}
 
 type ScannerFunc func(string) bool
@@ -39,7 +39,7 @@ func countFromFile(path string) (uint, error) {
 	var count uint
 	file, err := os.Open(path)
 	if err != nil {
-		return 0, errors.Wrap(err, "failed to open blocklist file for counting")
+		return 0, err
 	}
 	defer func() { _ = file.Close() }()
 	err = scanBlocklist(file, nil, func(_ string) bool {
@@ -52,8 +52,39 @@ func countFromFile(path string) (uint, error) {
 func streamFromFile(path string, logger *slog.Logger, handler ScannerFunc) error {
 	file, err := os.Open(path)
 	if err != nil {
-		return errors.Wrap(err, "failed to open blocklist file for streaming")
+		return err
 	}
 	defer func() { _ = file.Close() }()
 	return scanBlocklist(file, logger, handler)
+}
+
+func extractMetadata(path string) (map[string]string, error) {
+	file, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = file.Close() }()
+
+	metadata := make(map[string]string)
+	scanner := bufio.NewScanner(file)
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if line == "#" {
+			break // end of metadata header
+		}
+		after, ok := strings.CutPrefix(line, "# ")
+		if !ok {
+			continue
+		}
+		if key, value, found := strings.Cut(after, ": "); found {
+			metadata[snakeCase(key)] = value
+		}
+	}
+	return metadata, scanner.Err()
+}
+
+func snakeCase(s string) string {
+	s = strings.ToLower(s)
+	s = nonAlphanumeric.ReplaceAllString(s, "_")
+	return strings.Trim(s, "_")
 }

--- a/internal/blocklist/loader.go
+++ b/internal/blocklist/loader.go
@@ -72,6 +72,9 @@ func extractMetadata(path string) (map[string]string, error) {
 		if line == "#" {
 			break // end of metadata header
 		}
+		if line != "" && !strings.HasPrefix(line, "#") {
+			break
+		}
 		after, ok := strings.CutPrefix(line, "# ")
 		if !ok {
 			continue

--- a/internal/blocklist/loader.go
+++ b/internal/blocklist/loader.go
@@ -17,8 +17,11 @@ func scanBlocklist(file *os.File, logger *slog.Logger, handler ScannerFunc) erro
 	scanner := bufio.NewScanner(file)
 	for scanner.Scan() {
 		line := strings.TrimSpace(scanner.Text())
-		if strings.HasPrefix(line, "# ") && logger != nil {
-			logger.Info("Blocklist", "comment", line)
+		if strings.HasPrefix(line, "# ") {
+			if logger != nil {
+				logger.Info("Blocklist", "comment", line)
+			}
+			continue
 		} else if len(strings.Trim(line, "# ")) == 0 || strings.HasPrefix(line, "## ") {
 			continue // ignore double-octothorpe and empty comments
 		} else {

--- a/internal/blocklist/loader.go
+++ b/internal/blocklist/loader.go
@@ -1,0 +1,60 @@
+package blocklist
+
+import (
+	"bufio"
+	"log/slog"
+	"os"
+	"strings"
+
+	"github.com/cockroachdb/errors"
+)
+
+var prefixes = []string{"0.0.0.0 ", "*.", "www."}
+
+func scanBlocklist(file *os.File, logger *slog.Logger, handler func(string)) error {
+	scanner := bufio.NewScanner(file)
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if strings.HasPrefix(line, "# ") {
+			logger.Info("Blocklist", "comment", line)
+		} else if len(strings.Trim(line, "# ")) == 0 || strings.HasPrefix(line, "## ") {
+			continue // ignore double-octothorpe and empty comments
+		} else {
+			for _, prefix := range prefixes {
+				if after, ok := strings.CutPrefix(line, prefix); ok {
+					line = after
+				}
+			}
+			handler(line)
+		}
+	}
+	return scanner.Err()
+}
+
+func countFromFile(path string, logger *slog.Logger) (uint, error) {
+	var count uint
+	file, err := os.Open(path)
+	if err != nil {
+		return 0, errors.Wrap(err, "failed to open blocklist file for counting")
+	}
+	defer func() { _ = file.Close() }()
+	err = scanBlocklist(file, logger, func(_ string) {
+		count++
+	})
+	return count, err
+}
+
+func streamFromFile(path string, logger *slog.Logger, handler func(string)) error {
+	file, err := os.Open(path)
+	if err != nil {
+		return errors.Wrap(err, "failed to open blocklist file for streaming")
+	}
+	defer func() { _ = file.Close() }()
+	return scanBlocklist(file, logger, handler)
+}
+
+// func streamHosts(url string, logger *slog.Logger, handler func(string)) error {
+// 	return downloader.TransientDownload(logger, "", "blocklist-stream", url, "", func(tmpFile string, header http.Header) error {
+// 		return streamFromFile(tmpFile, logger, handler)
+// 	})
+// }

--- a/internal/blocklist/loader_test.go
+++ b/internal/blocklist/loader_test.go
@@ -1,0 +1,62 @@
+package blocklist
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestLoader_Metadata(t *testing.T) {
+	// Create a temporary file with header metadata
+	tmpDir, _ := os.MkdirTemp("", "blocklist-test")
+	defer func() { _ = os.RemoveAll(tmpDir) }()
+
+	tmpFile := filepath.Join(tmpDir, "metadata.txt")
+	content := "# Title: Test Blocklist\n# Author: Tester\n#\nexample.com\nmalicious.net\n"
+	_ = os.WriteFile(tmpFile, []byte(content), 0644)
+
+	// Test extractMetadata
+	metadata, err := extractMetadata(tmpFile)
+	assert.NoError(t, err)
+	assert.Equal(t, "Test Blocklist", metadata["title"])
+	assert.Equal(t, "Tester", metadata["author"])
+}
+
+func TestLoader_Count(t *testing.T) {
+	// Create a temporary file
+	tmpDir, _ := os.MkdirTemp("", "blocklist-test")
+	defer func() { _ = os.RemoveAll(tmpDir) }()
+
+	tmpFile := filepath.Join(tmpDir, "count.txt")
+	content := "# Title: Test\nexample.com\n# Comment\nmalicious.net\n"
+	_ = os.WriteFile(tmpFile, []byte(content), 0644)
+
+	// Test countFromFile
+	count, err := countFromFile(tmpFile)
+	assert.NoError(t, err)
+	// Current behavior: counts comments when logger is nil
+	assert.Equal(t, uint(4), count)
+}
+
+func TestLoader_Stream(t *testing.T) {
+	tmpDir, _ := os.MkdirTemp("", "blocklist-test")
+	defer func() { _ = os.RemoveAll(tmpDir) }()
+
+	tmpFile := filepath.Join(tmpDir, "list.txt")
+	content := "# Title: Test Blocklist\n# Author: Tester\n#\nexample.com\nmalicious.net\n"
+	_ = os.WriteFile(tmpFile, []byte(content), 0644)
+
+	var hosts []string
+	scannerFunc := func(host string) bool {
+		hosts = append(hosts, host)
+		return false
+	}
+
+	err := streamFromFile(tmpFile, nil, scannerFunc)
+	assert.NoError(t, err)
+	assert.Equal(t, 2, len(hosts))
+	assert.Contains(t, hosts, "example.com")
+	assert.Contains(t, hosts, "malicious.net")
+}

--- a/internal/blocklist/loader_test.go
+++ b/internal/blocklist/loader_test.go
@@ -8,16 +8,25 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func TestMain(m *testing.M) {
+	// Any global setup can go here
+	os.Exit(m.Run())
+}
+
+func setupTempFile(t *testing.T, content string) string {
+	tmpDir, err := os.MkdirTemp("", "blocklist-test")
+	assert.NoError(t, err)
+	t.Cleanup(func() { _ = os.RemoveAll(tmpDir) })
+
+	tmpFile := filepath.Join(tmpDir, "list.txt")
+	err = os.WriteFile(tmpFile, []byte(content), 0644)
+	assert.NoError(t, err)
+	return tmpFile
+}
+
 func TestLoader_Metadata(t *testing.T) {
-	// Create a temporary file with header metadata
-	tmpDir, _ := os.MkdirTemp("", "blocklist-test")
-	defer func() { _ = os.RemoveAll(tmpDir) }()
+	tmpFile := setupTempFile(t, "# Title: Test Blocklist\n# Author: Tester\n#\nexample.com\nmalicious.net\n")
 
-	tmpFile := filepath.Join(tmpDir, "metadata.txt")
-	content := "# Title: Test Blocklist\n# Author: Tester\n#\nexample.com\nmalicious.net\n"
-	_ = os.WriteFile(tmpFile, []byte(content), 0644)
-
-	// Test extractMetadata
 	metadata, err := extractMetadata(tmpFile)
 	assert.NoError(t, err)
 	assert.Equal(t, "Test Blocklist", metadata["title"])
@@ -25,28 +34,15 @@ func TestLoader_Metadata(t *testing.T) {
 }
 
 func TestLoader_Count(t *testing.T) {
-	// Create a temporary file
-	tmpDir, _ := os.MkdirTemp("", "blocklist-test")
-	defer func() { _ = os.RemoveAll(tmpDir) }()
+	tmpFile := setupTempFile(t, "# Title: Test\nexample.com\n# Comment\nmalicious.net\n")
 
-	tmpFile := filepath.Join(tmpDir, "count.txt")
-	content := "# Title: Test\nexample.com\n# Comment\nmalicious.net\n"
-	_ = os.WriteFile(tmpFile, []byte(content), 0644)
-
-	// Test countFromFile
 	count, err := countFromFile(tmpFile)
 	assert.NoError(t, err)
-	// Current behavior: counts comments when logger is nil
-	assert.Equal(t, uint(4), count)
+	assert.Equal(t, 2, int(count))
 }
 
 func TestLoader_Stream(t *testing.T) {
-	tmpDir, _ := os.MkdirTemp("", "blocklist-test")
-	defer func() { _ = os.RemoveAll(tmpDir) }()
-
-	tmpFile := filepath.Join(tmpDir, "list.txt")
-	content := "# Title: Test Blocklist\n# Author: Tester\n#\nexample.com\nmalicious.net\n"
-	_ = os.WriteFile(tmpFile, []byte(content), 0644)
+	tmpFile := setupTempFile(t, "# Title: Test Blocklist\n# Author: Tester\n#\nexample.com\nmalicious.net\n")
 
 	var hosts []string
 	scannerFunc := func(host string) bool {

--- a/internal/blocklist/update.go
+++ b/internal/blocklist/update.go
@@ -11,7 +11,7 @@ func NewUpdater(blocklists []*BlockList) *Updater {
 func (job *Updater) Run() {
 	for _, blockList := range job.Blocklists {
 		if err := blockList.Fetch(); err != nil {
-			blockList.logger.Error("failed to download blocklist for cron reload",
+			blockList.logger.Error("failed to download blocklist",
 				"error", err,
 				"name", blockList.name,
 				"url", blockList.url)

--- a/internal/blocklist/update.go
+++ b/internal/blocklist/update.go
@@ -1,144 +1,20 @@
 package blocklist
 
-import (
-	"bufio"
-	"log/slog"
-	"net/http"
-	"os"
-	"strings"
-
-	"github.com/bits-and-blooms/bloom/v3"
-	"github.com/cockroachdb/errors"
-	"github.com/rm-hull/dot-block/internal/downloader"
-)
-
-var prefixes = []string{"0.0.0.0 ", "*.", "www."}
-
-type BlocklistUpdater struct {
-	Blocklist *BlockList
-	URLs      []string
+type Updater struct {
+	Blocklists []BlockList
 }
 
-func NewBlocklistUpdater(blocklist *BlockList, urls []string) *BlocklistUpdater {
-	return &BlocklistUpdater{
-		Blocklist: blocklist,
-		URLs:      urls,
-	}
+func NewUpdater(blocklists []BlockList) *Updater {
+	return &Updater{Blocklists: blocklists}
 }
 
-func (job *BlocklistUpdater) Run() {
-	if err := LoadFromURLs(job.Blocklist, job.URLs); err != nil {
-		job.Blocklist.logger.Error("failed to download blocklist for cron reload", "error", err)
-	}
-}
-
-func LoadFromURLs(bl *BlockList, urls []string) error {
-	type downloadedFile struct {
-		path   string
-		url    string
-		isTemp bool
-	}
-	files := make([]downloadedFile, 0, len(urls))
-
-	defer func() {
-		for _, f := range files {
-			if f.isTemp {
-				_ = os.Remove(f.path)
-			}
-		}
-	}()
-
-	for _, url := range urls {
-		path, _, isTemp, err := downloader.Download(bl.logger, "", "blocklist", url, "")
-		if err != nil {
-			return errors.Wrapf(err, "failed to download blocklist for counting: %s", url)
-		}
-		files = append(files, downloadedFile{path: path, url: url, isTemp: isTemp})
-	}
-
-	var totalCount uint
-	for _, f := range files {
-		count, err := countFromFile(f.path, bl.logger)
-		if err != nil {
-			return errors.Wrapf(err, "failed to count hosts in file %s (url: %s)", f.path, f.url)
-		}
-		totalCount += uint(count)
-	}
-
-	// Avoid creating a bloom filter with 0 items, which will panic
-	if totalCount == 0 {
-		totalCount = 1
-	}
-
-	bf := bloom.NewWithEstimates(totalCount, bl.fpRate)
-	for _, f := range files {
-		if err := streamFromFile(f.path, bl.logger, func(host string) {
-			bf.AddString(host)
-		}); err != nil {
-			return errors.Wrapf(err, "failed to stream hosts from file %s (url: %s)", f.path, f.url)
+func (job *Updater) Run() {
+	for _, blockList := range job.Blocklists {
+		if err := blockList.LoadFromURL(); err != nil {
+			blockList.logger.Error("failed to download blocklist for cron reload",
+				"error", err,
+				"name", blockList.name,
+				"url", blockList.url)
 		}
 	}
-
-	bl.ApplyBloomFilter(bf, totalCount)
-	return nil
-}
-
-func Fetch(url string, logger *slog.Logger) ([]string, error) {
-	blocklist := make([]string, 0, 100_000)
-	err := streamHosts(url, logger, func(host string) {
-		blocklist = append(blocklist, host)
-	})
-
-	if err == nil {
-		logger.Info("Blocklist loaded successfully", "count", len(blocklist))
-	}
-	return blocklist, err
-}
-
-func scanBlocklist(file *os.File, logger *slog.Logger, handler func(string)) error {
-	scanner := bufio.NewScanner(file)
-	for scanner.Scan() {
-		line := strings.TrimSpace(scanner.Text())
-		if strings.HasPrefix(line, "# ") {
-			logger.Info("Blocklist", "comment", line)
-		} else if len(strings.Trim(line, "# ")) == 0 || strings.HasPrefix(line, "## ") {
-			continue // ignore double-octothorpe and empty comments
-		} else {
-			for _, prefix := range prefixes {
-				if after, ok := strings.CutPrefix(line, prefix); ok {
-					line = after
-				}
-			}
-			handler(line)
-		}
-	}
-	return scanner.Err()
-}
-
-func countFromFile(path string, logger *slog.Logger) (int, error) {
-	count := 0
-	file, err := os.Open(path)
-	if err != nil {
-		return 0, errors.Wrap(err, "failed to open blocklist file for counting")
-	}
-	defer func() { _ = file.Close() }()
-	err = scanBlocklist(file, logger, func(_ string) {
-		count++
-	})
-	return count, err
-}
-
-func streamFromFile(path string, logger *slog.Logger, handler func(string)) error {
-	file, err := os.Open(path)
-	if err != nil {
-		return errors.Wrap(err, "failed to open blocklist file for streaming")
-	}
-	defer func() { _ = file.Close() }()
-	return scanBlocklist(file, logger, handler)
-}
-
-func streamHosts(url string, logger *slog.Logger, handler func(string)) error {
-	return downloader.TransientDownload(logger, "", "blocklist-stream", url, "", func(tmpFile string, header http.Header) error {
-		return streamFromFile(tmpFile, logger, handler)
-	})
 }

--- a/internal/blocklist/update.go
+++ b/internal/blocklist/update.go
@@ -1,10 +1,10 @@
 package blocklist
 
 type Updater struct {
-	Blocklists []BlockList
+	Blocklists []*BlockList
 }
 
-func NewUpdater(blocklists []BlockList) *Updater {
+func NewUpdater(blocklists []*BlockList) *Updater {
 	return &Updater{Blocklists: blocklists}
 }
 

--- a/internal/blocklist/update.go
+++ b/internal/blocklist/update.go
@@ -10,7 +10,7 @@ func NewUpdater(blocklists []BlockList) *Updater {
 
 func (job *Updater) Run() {
 	for _, blockList := range job.Blocklists {
-		if err := blockList.LoadFromURL(); err != nil {
+		if err := blockList.Fetch(); err != nil {
 			blockList.logger.Error("failed to download blocklist for cron reload",
 				"error", err,
 				"name", blockList.name,

--- a/internal/blocklist/update_test.go
+++ b/internal/blocklist/update_test.go
@@ -1,0 +1,19 @@
+package blocklist
+
+import (
+	"log/slog"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestUpdater_Run(t *testing.T) {
+	// Use slog.Default() to prevent nil pointer in Fetch()
+	bls := []*BlockList{
+		NewBlockList("list1", "http://localhost:8080/does-not-exist", 0.001, slog.Default()),
+	}
+	updater := NewUpdater(bls)
+
+	// Expect Run() to return without panicking
+	assert.NotPanics(t, func() { updater.Run() })
+}

--- a/internal/check_test.go
+++ b/internal/check_test.go
@@ -23,7 +23,7 @@ func TestCheckHandler(t *testing.T) {
 	// Use a small blocklist for testing
 	blockList := blocklist.NewBlockList("test", "http://dummy.url", 0.0001, logger)
 	blockList.Load([]string{"blocked.com", "ads.net"})
-	updater := blocklist.NewUpdater([]blocklist.BlockList{*blockList})
+	updater := blocklist.NewUpdater([]*blocklist.BlockList{blockList})
 
 	handler := handlers.NewBlocklistHandler(updater, logger)
 

--- a/internal/check_test.go
+++ b/internal/check_test.go
@@ -21,8 +21,9 @@ func TestCheckHandler(t *testing.T) {
 
 	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
 	// Use a small blocklist for testing
-	blockList := blocklist.NewBlockList("test", []string{"blocked.com", "ads.net"}, 0.0001, logger)
-	updater := blocklist.NewBlocklistUpdater(blockList, []string{})
+	blockList := blocklist.NewBlockList("test", "http://dummy.url", 0.0001, logger)
+	blockList.Load([]string{"blocked.com", "ads.net"})
+	updater := blocklist.NewUpdater([]blocklist.BlockList{*blockList})
 
 	handler := handlers.NewBlocklistHandler(updater, logger)
 

--- a/internal/forwarder/dispatcher.go
+++ b/internal/forwarder/dispatcher.go
@@ -55,7 +55,7 @@ type DNSDispatcher struct {
 	defaultTTL  float64
 	ttlFloor    time.Duration
 	cache       *DNSCache
-	blockLists  []blocklist.BlockList
+	blockLists  []*blocklist.BlockList
 	metrics     *metrics.DnsMetrics
 	logger      *slog.Logger
 	noiseFilter *noisefilter.NoiseFilter
@@ -69,7 +69,7 @@ func NewDNSDispatcher(
 	cache *DNSCache,
 	dnsMetrics *metrics.DnsMetrics,
 	dnsClient *RoundRobinClient,
-	blockLists []blocklist.BlockList,
+	blockLists []*blocklist.BlockList,
 	noiseFilter *noisefilter.NoiseFilter,
 	broadcaster *sse.Broadcaster,
 	ttlFloor time.Duration,
@@ -644,7 +644,7 @@ func isReservedLocalhost(name string) bool {
 func (d *DNSDispatcher) isBlocked(fqdn string) (bool, *blocklist.BlockList, error) {
 	for _, blockList := range d.blockLists {
 		if isBlocked, err := blockList.IsBlocked(fqdn); isBlocked || err != nil {
-			return isBlocked, &blockList, err
+			return isBlocked, blockList, err
 		}
 	}
 	return false, nil, nil

--- a/internal/forwarder/dispatcher.go
+++ b/internal/forwarder/dispatcher.go
@@ -55,7 +55,7 @@ type DNSDispatcher struct {
 	defaultTTL  float64
 	ttlFloor    time.Duration
 	cache       *DNSCache
-	blockList   *blocklist.BlockList
+	blockLists  []blocklist.BlockList
 	metrics     *metrics.DnsMetrics
 	logger      *slog.Logger
 	noiseFilter *noisefilter.NoiseFilter
@@ -69,7 +69,7 @@ func NewDNSDispatcher(
 	cache *DNSCache,
 	dnsMetrics *metrics.DnsMetrics,
 	dnsClient *RoundRobinClient,
-	blockList *blocklist.BlockList,
+	blockLists []blocklist.BlockList,
 	noiseFilter *noisefilter.NoiseFilter,
 	broadcaster *sse.Broadcaster,
 	ttlFloor time.Duration,
@@ -86,7 +86,7 @@ func NewDNSDispatcher(
 		defaultTTL:  300, // TODO: pass in
 		ttlFloor:    ttlFloor,
 		cache:       cache,
-		blockList:   blockList,
+		blockLists:  blockLists,
 		metrics:     dnsMetrics,
 		logger:      logger,
 		noiseFilter: noiseFilter,
@@ -282,7 +282,7 @@ func (d *DNSDispatcher) processQuestion(requestCtx *RequestContext, q *dns.Quest
 		"name", q.Name,
 		"type", queryType)
 
-	isBlocked, err := d.blockList.IsBlocked(q.Name)
+	isBlocked, cause, err := d.isBlocked(q.Name)
 	if err != nil {
 		span.RecordError(err)
 		span.SetStatus(codes.Error, err.Error())
@@ -291,7 +291,7 @@ func (d *DNSDispatcher) processQuestion(requestCtx *RequestContext, q *dns.Quest
 	}
 
 	if isBlocked {
-		return d.constructBlockedResponse(requestCtx, q, queryType), nil
+		return d.constructBlockedResponse(requestCtx, q, queryType, cause), nil
 	}
 
 	if isReservedLocalhost(q.Name) {
@@ -330,8 +330,8 @@ func (d *DNSDispatcher) processQuestion(requestCtx *RequestContext, q *dns.Quest
 	return QuestionResolution{rcode: dns.RcodeSuccess}, nil
 }
 
-func (d *DNSDispatcher) constructBlockedResponse(requestCtx *RequestContext, q *dns.Question, queryType string) QuestionResolution {
-	requestCtx.logger.DebugContext(requestCtx.ctx, "Domain blocked", "name", q.Name)
+func (d *DNSDispatcher) constructBlockedResponse(requestCtx *RequestContext, q *dns.Question, queryType string, cause *blocklist.BlockList) QuestionResolution {
+	requestCtx.logger.DebugContext(requestCtx.ctx, "Domain blocked", "name", q.Name, "cause", cause.Name())
 	requestCtx.snapshot.AddBlockedDomain(q.Name)
 	requestCtx.snapshot.AddQueryCount(queryType, true)
 
@@ -354,7 +354,7 @@ func (d *DNSDispatcher) constructBlockedResponse(requestCtx *RequestContext, q *
 	// Inject EDE for blocked domain
 	ede := &dns.EDNS0_EDE{
 		InfoCode:  dns.ExtendedErrorCodeBlocked,
-		ExtraText: fmt.Sprintf("Blocked by policy: %s", q.Name),
+		ExtraText: fmt.Sprintf("Blocked by: %s", cause.Name()),
 	}
 
 	var extra []dns.RR
@@ -639,4 +639,13 @@ func isReservedTLD(name string) bool {
 
 func isReservedLocalhost(name string) bool {
 	return strings.ToLower(name) == "localhost."
+}
+
+func (d *DNSDispatcher) isBlocked(fqdn string) (bool, *blocklist.BlockList, error) {
+	for _, blockList := range d.blockLists {
+		if isBlocked, err := blockList.IsBlocked(fqdn); isBlocked || err != nil {
+			return isBlocked, &blockList, err
+		}
+	}
+	return false, nil, nil
 }

--- a/internal/forwarder/dispatcher_test.go
+++ b/internal/forwarder/dispatcher_test.go
@@ -88,7 +88,8 @@ func setupDispatcherTest(t *testing.T, upstream string, logger *slog.Logger, ena
 	if logger == nil {
 		logger = slog.New(slog.NewTextHandler(io.Discard, nil))
 	}
-	blockList := blocklist.NewBlockList("test", []string{"ads.0xbt.net"}, 0.0001, logger)
+	blockList := blocklist.NewBlockList("dispatcher_test", "http://dummy.url", 0.0001, logger)
+	blockList.Load([]string{"ads.0xbt.net"})
 
 	cache := NewDNSCache(100, logger)
 	mockGeo := new(MockGeoIpLookup)
@@ -100,7 +101,7 @@ func setupDispatcherTest(t *testing.T, upstream string, logger *slog.Logger, ena
 	dnsClient, err := NewRoundRobinClient(metrics, 2*time.Second, 2*time.Second, 2*time.Second, logger, upstream)
 	require.NoError(t, err)
 
-	dispatcher, err := NewDNSDispatcher(cache, metrics, dnsClient, blockList, noisefilter.NewNoiseFilter(), sse.NewBroadcaster(logger), 1*time.Minute, logger, enableECS)
+	dispatcher, err := NewDNSDispatcher(cache, metrics, dnsClient, []blocklist.BlockList{*blockList}, noisefilter.NewNoiseFilter(), sse.NewBroadcaster(logger), 1*time.Minute, logger, enableECS)
 	require.NoError(t, err)
 	t.Cleanup(dispatcher.Close)
 
@@ -262,7 +263,7 @@ func TestDNSDispatcher_HandleDNSRequest_BlockedIncludesEDE(t *testing.T) {
 	ede, ok := opt.Option[0].(*dns.EDNS0_EDE)
 	require.True(t, ok, "expected EDE option")
 	assert.Equal(t, dns.ExtendedErrorCodeBlocked, ede.InfoCode)
-	assert.Contains(t, ede.ExtraText, "Blocked by policy")
+	assert.Contains(t, ede.ExtraText, "Blocked by: dispatcher_test")
 }
 
 func TestDNSDispatcher_HandleDNSRequest_MultipleQuestions(t *testing.T) {
@@ -421,7 +422,8 @@ func TestDNSDispatcher_ResolveUpstream_BadRCode(t *testing.T) {
 
 func TestDNSDispatcher_NegativeCacheTtlFloor(t *testing.T) {
 	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
-	blockList := blocklist.NewBlockList("test", []string{"ads.0xbt.net"}, 0.0001, logger)
+	blockList := blocklist.NewBlockList("test", "http://dummy.url", 0.0001, logger)
+	blockList.Load([]string{"ads.0xbt.net"})
 
 	cache := NewDNSCache(100, logger)
 	mockGeo := new(MockGeoIpLookup)
@@ -433,7 +435,7 @@ func TestDNSDispatcher_NegativeCacheTtlFloor(t *testing.T) {
 	dnsClient, err := NewRoundRobinClient(metrics, 2*time.Second, 2*time.Second, 2*time.Second, logger, "8.8.8.8:53")
 	assert.NoError(t, err)
 
-	dispatcher, err := NewDNSDispatcher(cache, metrics, dnsClient, blockList, noisefilter.NewNoiseFilter(), sse.NewBroadcaster(logger), -1*time.Second, logger, false)
+	dispatcher, err := NewDNSDispatcher(cache, metrics, dnsClient, []blocklist.BlockList{*blockList}, noisefilter.NewNoiseFilter(), sse.NewBroadcaster(logger), -1*time.Second, logger, false)
 	assert.Error(t, err)
 	assert.Nil(t, dispatcher)
 	assert.Contains(t, err.Error(), "TTL floor cannot be negative")
@@ -752,14 +754,16 @@ func TestDNSDispatcher_ECS_Injection(t *testing.T) {
 
 			// Setup dispatcher with the specific enableECS setting
 			logger := slog.New(slog.NewTextHandler(io.Discard, nil))
-			blockList := blocklist.NewBlockList("test", []string{}, 0.0001, logger)
+			blockList := blocklist.NewBlockList("test", "http://dummy.url", 0.0001, logger)
+			blockList.Load([]string{"ads.com"})
+
 			cache := NewDNSCache(100, logger)
 			mockGeo := new(MockGeoIpLookup)
 			mockGeo.On("GetAll", mock.Anything).Return(geoblock.GeoData{}, nil)
 			metrics, _ := metrics.NewDNSMetrics(cache, mockGeo)
 			dnsClient, _ := NewRoundRobinClient(metrics, 2*time.Second, 2*time.Second, 2*time.Second, logger, upstream)
 
-			dispatcher, _ := NewDNSDispatcher(cache, metrics, dnsClient, blockList, noisefilter.NewNoiseFilter(), sse.NewBroadcaster(logger), 1*time.Minute, logger, tt.enableECS)
+			dispatcher, _ := NewDNSDispatcher(cache, metrics, dnsClient, []blocklist.BlockList{*blockList}, noisefilter.NewNoiseFilter(), sse.NewBroadcaster(logger), 1*time.Minute, logger, tt.enableECS)
 			defer dispatcher.Close()
 
 			// Mock ResponseWriter with the specific client IP

--- a/internal/forwarder/dispatcher_test.go
+++ b/internal/forwarder/dispatcher_test.go
@@ -101,7 +101,7 @@ func setupDispatcherTest(t *testing.T, upstream string, logger *slog.Logger, ena
 	dnsClient, err := NewRoundRobinClient(metrics, 2*time.Second, 2*time.Second, 2*time.Second, logger, upstream)
 	require.NoError(t, err)
 
-	dispatcher, err := NewDNSDispatcher(cache, metrics, dnsClient, []blocklist.BlockList{*blockList}, noisefilter.NewNoiseFilter(), sse.NewBroadcaster(logger), 1*time.Minute, logger, enableECS)
+	dispatcher, err := NewDNSDispatcher(cache, metrics, dnsClient, []*blocklist.BlockList{blockList}, noisefilter.NewNoiseFilter(), sse.NewBroadcaster(logger), 1*time.Minute, logger, enableECS)
 	require.NoError(t, err)
 	t.Cleanup(dispatcher.Close)
 
@@ -435,7 +435,7 @@ func TestDNSDispatcher_NegativeCacheTtlFloor(t *testing.T) {
 	dnsClient, err := NewRoundRobinClient(metrics, 2*time.Second, 2*time.Second, 2*time.Second, logger, "8.8.8.8:53")
 	assert.NoError(t, err)
 
-	dispatcher, err := NewDNSDispatcher(cache, metrics, dnsClient, []blocklist.BlockList{*blockList}, noisefilter.NewNoiseFilter(), sse.NewBroadcaster(logger), -1*time.Second, logger, false)
+	dispatcher, err := NewDNSDispatcher(cache, metrics, dnsClient, []*blocklist.BlockList{blockList}, noisefilter.NewNoiseFilter(), sse.NewBroadcaster(logger), -1*time.Second, logger, false)
 	assert.Error(t, err)
 	assert.Nil(t, dispatcher)
 	assert.Contains(t, err.Error(), "TTL floor cannot be negative")
@@ -763,7 +763,7 @@ func TestDNSDispatcher_ECS_Injection(t *testing.T) {
 			metrics, _ := metrics.NewDNSMetrics(cache, mockGeo)
 			dnsClient, _ := NewRoundRobinClient(metrics, 2*time.Second, 2*time.Second, 2*time.Second, logger, upstream)
 
-			dispatcher, _ := NewDNSDispatcher(cache, metrics, dnsClient, []blocklist.BlockList{*blockList}, noisefilter.NewNoiseFilter(), sse.NewBroadcaster(logger), 1*time.Minute, logger, tt.enableECS)
+			dispatcher, _ := NewDNSDispatcher(cache, metrics, dnsClient, []*blocklist.BlockList{blockList}, noisefilter.NewNoiseFilter(), sse.NewBroadcaster(logger), 1*time.Minute, logger, tt.enableECS)
 			defer dispatcher.Close()
 
 			// Mock ResponseWriter with the specific client IP

--- a/internal/http/handlers/blocklist.go
+++ b/internal/http/handlers/blocklist.go
@@ -145,7 +145,7 @@ func (h *BlocklistHandler) Check(c *gin.Context) {
 func (h *BlocklistHandler) isBlocked(fqdn string) (bool, *blocklist.BlockList, error) {
 	for _, blockList := range h.updater.Blocklists {
 		if isBlocked, err := blockList.IsBlocked(fqdn); isBlocked || err != nil {
-			return isBlocked, &blockList, err
+			return isBlocked, blockList, err
 		}
 	}
 	return false, nil, nil

--- a/internal/http/handlers/blocklist.go
+++ b/internal/http/handlers/blocklist.go
@@ -12,24 +12,30 @@ import (
 )
 
 type BlocklistHandler struct {
-	updater *blocklist.BlocklistUpdater
+	updater *blocklist.Updater
 	logger  *slog.Logger
 }
 
-func NewBlocklistHandler(updater *blocklist.BlocklistUpdater, logger *slog.Logger) *BlocklistHandler {
+func NewBlocklistHandler(updater *blocklist.Updater, logger *slog.Logger) *BlocklistHandler {
 	return &BlocklistHandler{updater: updater, logger: logger}
 }
 
 func (h *BlocklistHandler) Reload(c *gin.Context) {
 	go h.updater.Run()
+	m := make(map[string]string, 0)
+	for _, blockList := range h.updater.Blocklists {
+		m[blockList.Name()] = blockList.URL()
+	}
+
 	c.JSON(http.StatusAccepted, gin.H{
-		"message": "Blocklist reload triggered",
-		"urls":    h.updater.URLs,
+		"message":    "Blocklist reload triggered",
+		"blocklists": m,
 	})
 }
 
 func (h *BlocklistHandler) Disable(c *gin.Context) {
 	var payload struct {
+		Name     string `json:"name,omitempty"`
 		Duration string `json:"duration"`
 	}
 	if err := c.ShouldBindJSON(&payload); err != nil {
@@ -54,24 +60,29 @@ func (h *BlocklistHandler) Disable(c *gin.Context) {
 		return
 	}
 
-	disabledUntil := h.updater.Blocklist.Disable(d)
-	c.JSON(http.StatusOK, gin.H{
-		"message":  "Blocklist temporarily disabled",
-		"duration": d.String(),
-		"until":    disabledUntil,
-	})
+	for _, bl := range h.updater.Blocklists {
+		if payload.Name == bl.Name() || payload.Name == "" {
+			bl.Disable(d)
+		}
+	}
+
+	h.Status(c)
 }
 
 func (h *BlocklistHandler) Reenable(c *gin.Context) {
-	if h.updater.Blocklist.Reenable() {
-		c.JSON(http.StatusOK, gin.H{"message": "Blocklist re-enabled"})
-	} else {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "Blocklist is not currently disabled"})
+	for _, bl := range h.updater.Blocklists {
+		bl.Reenable()
 	}
+
+	h.Status(c)
 }
 
 func (h *BlocklistHandler) Status(c *gin.Context) {
-	c.JSON(http.StatusOK, h.updater.Blocklist.Status())
+	blocklists := make(map[string]*blocklist.BlocklistStatus)
+	for _, bl := range h.updater.Blocklists {
+		blocklists[bl.Name()] = bl.Status()
+	}
+	c.JSON(http.StatusOK, blocklists)
 }
 
 func (h *BlocklistHandler) Check(c *gin.Context) {
@@ -112,7 +123,7 @@ func (h *BlocklistHandler) Check(c *gin.Context) {
 	blocked := make([]string, 0)
 
 	for _, domain := range domains {
-		isBlocked, err := h.updater.Blocklist.IsBlocked(domain)
+		isBlocked, _, err := h.isBlocked(domain)
 		if err != nil {
 			h.logger.Error("blocklist check failed", "error", err, "domain", domain)
 			c.JSON(http.StatusInternalServerError, gin.H{"error": "Internal server error"})
@@ -129,4 +140,13 @@ func (h *BlocklistHandler) Check(c *gin.Context) {
 		"allowed": allowed,
 		"blocked": blocked,
 	})
+}
+
+func (h *BlocklistHandler) isBlocked(fqdn string) (bool, *blocklist.BlockList, error) {
+	for _, blockList := range h.updater.Blocklists {
+		if isBlocked, err := blockList.IsBlocked(fqdn); isBlocked || err != nil {
+			return isBlocked, &blockList, err
+		}
+	}
+	return false, nil, nil
 }

--- a/internal/http/handlers/blocklist.go
+++ b/internal/http/handlers/blocklist.go
@@ -22,7 +22,7 @@ func NewBlocklistHandler(updater *blocklist.Updater, logger *slog.Logger) *Block
 
 func (h *BlocklistHandler) Reload(c *gin.Context) {
 	go h.updater.Run()
-	m := make(map[string]string, 0)
+	m := make(map[string]string, len(h.updater.Blocklists))
 	for _, blockList := range h.updater.Blocklists {
 		m[blockList.Name()] = blockList.URL()
 	}

--- a/internal/http/handlers/blocklist_test.go
+++ b/internal/http/handlers/blocklist_test.go
@@ -13,16 +13,18 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestBlocklistHandler_Status(t *testing.T) {
+func setupHandler(t *testing.T) (*BlocklistHandler, *slog.Logger) {
 	gin.SetMode(gin.TestMode)
+	logger := slog.Default()
 	updater := blocklist.NewUpdater([]*blocklist.BlockList{})
-	h := NewBlocklistHandler(updater, nil)
+	return NewBlocklistHandler(updater, logger), logger
+}
 
+func TestBlocklistHandler_Status(t *testing.T) {
+	h, _ := setupHandler(t)
 	w := httptest.NewRecorder()
 	c, _ := gin.CreateTestContext(w)
-
 	h.Status(c)
-
 	assert.Equal(t, http.StatusOK, w.Code)
 }
 
@@ -42,7 +44,6 @@ func TestBlocklistHandler_Disable(t *testing.T) {
 	h.Disable(c)
 
 	assert.Equal(t, http.StatusOK, w.Code)
-	// Verify status reflects disabled state
 	statusBody := w.Body.String()
 	assert.Contains(t, statusBody, "disabled_until")
 }
@@ -55,7 +56,6 @@ func TestBlocklistHandler_Disable_All(t *testing.T) {
 	h := NewBlocklistHandler(updater, logger)
 
 	w := httptest.NewRecorder()
-	// Empty name should disable all
 	payload := `{"duration": "30m"}`
 	c, _ := gin.CreateTestContext(w)
 	c.Request = httptest.NewRequest("POST", "/disable", strings.NewReader(payload))
@@ -85,4 +85,79 @@ func TestBlocklistHandler_Reenable(t *testing.T) {
 	assert.Equal(t, http.StatusOK, w.Code)
 	statusBody := w.Body.String()
 	assert.NotContains(t, statusBody, "disabled_until")
+}
+
+func TestBlocklistHandler_Reload(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	logger := slog.Default()
+	bl := blocklist.NewBlockList("test", "http://localhost:9999/does-not-exist", 0.001, logger)
+	updater := blocklist.NewUpdater([]*blocklist.BlockList{bl})
+	h := NewBlocklistHandler(updater, logger)
+
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+
+	h.Reload(c)
+
+	assert.Equal(t, http.StatusAccepted, w.Code)
+	assert.NotEmpty(t, w.Body.String())
+}
+
+func TestBlocklistHandler_CheckInvalidJSON(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	logger := slog.Default()
+	updater := blocklist.NewUpdater([]*blocklist.BlockList{})
+	h := NewBlocklistHandler(updater, logger)
+
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest("POST", "/check", strings.NewReader(`not json`))
+	c.Request.Header.Set("Content-Type", "application/json")
+
+	h.Check(c)
+
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+	assert.Contains(t, w.Body.String(), "Invalid JSON")
+}
+
+func TestBlocklistHandler_CheckTooManyDomains(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	logger := slog.Default()
+	updater := blocklist.NewUpdater([]*blocklist.BlockList{})
+	h := NewBlocklistHandler(updater, logger)
+
+	// Create a JSON array with 101 items (limit is 100)
+	var sb strings.Builder
+	sb.WriteString("[")
+	for i := 0; i < 101; i++ {
+		if i > 0 {
+			sb.WriteString(",")
+		}
+		sb.WriteString(`"example.com"`)
+	}
+	sb.WriteString("]")
+	payload := sb.String()
+
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest("POST", "/check", strings.NewReader(payload))
+	c.Request.Header.Set("Content-Type", "application/json")
+
+	h.Check(c)
+
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+	assert.Contains(t, w.Body.String(), "Too many domains")
+}
+
+func TestBlocklistHandler_CheckInvalidDomain(t *testing.T) {
+	h, _ := setupHandler(t)
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest("POST", "/check", strings.NewReader(`[""]`))
+	c.Request.Header.Set("Content-Type", "application/json")
+
+	h.Check(c)
+
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+	assert.Contains(t, w.Body.String(), "Invalid domain")
 }

--- a/internal/http/handlers/blocklist_test.go
+++ b/internal/http/handlers/blocklist_test.go
@@ -1,0 +1,88 @@
+package handlers
+
+import (
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/rm-hull/dot-block/internal/blocklist"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestBlocklistHandler_Status(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	updater := blocklist.NewUpdater([]*blocklist.BlockList{})
+	h := NewBlocklistHandler(updater, nil)
+
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+
+	h.Status(c)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+}
+
+func TestBlocklistHandler_Disable(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	logger := slog.Default()
+	bl := blocklist.NewBlockList("test", "http://example.com/list.txt", 0.001, logger)
+	updater := blocklist.NewUpdater([]*blocklist.BlockList{bl})
+	h := NewBlocklistHandler(updater, logger)
+
+	w := httptest.NewRecorder()
+	payload := `{"name": "test", "duration": "1h"}`
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest("POST", "/disable", strings.NewReader(payload))
+	c.Request.Header.Set("Content-Type", "application/json")
+
+	h.Disable(c)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	// Verify status reflects disabled state
+	statusBody := w.Body.String()
+	assert.Contains(t, statusBody, "disabled_until")
+}
+
+func TestBlocklistHandler_Disable_All(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	logger := slog.Default()
+	bl := blocklist.NewBlockList("test", "http://example.com/list.txt", 0.001, logger)
+	updater := blocklist.NewUpdater([]*blocklist.BlockList{bl})
+	h := NewBlocklistHandler(updater, logger)
+
+	w := httptest.NewRecorder()
+	// Empty name should disable all
+	payload := `{"duration": "30m"}`
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest("POST", "/disable", strings.NewReader(payload))
+	c.Request.Header.Set("Content-Type", "application/json")
+
+	h.Disable(c)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+}
+
+func TestBlocklistHandler_Reenable(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	logger := slog.Default()
+	bl := blocklist.NewBlockList("test", "http://example.com/list.txt", 0.001, logger)
+	// Pre-disable it
+	bl.Disable(time.Hour)
+	updater := blocklist.NewUpdater([]*blocklist.BlockList{bl})
+	h := NewBlocklistHandler(updater, logger)
+
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest("POST", "/reenable", strings.NewReader("{}"))
+	c.Request.Header.Set("Content-Type", "application/json")
+
+	h.Reenable(c)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	statusBody := w.Body.String()
+	assert.NotContains(t, statusBody, "disabled_until")
+}

--- a/internal/integration_test.go
+++ b/internal/integration_test.go
@@ -32,12 +32,9 @@ func TestIntegration_DNSFunctionality(t *testing.T) {
 	dotPort := getFreePort(t)
 	httpPort := getFreePort(t)
 
-	handler := slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelDebug})
-	slog.SetDefault(slog.New(handler))
-
 	// App configuration for integration test
 	app := App{
-		Logger:         slog.Default(),
+		Logger:         slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelDebug})),
 		DevMode:        true,
 		DnsPort:        dnsPort,
 		DotPort:        dotPort,

--- a/internal/integration_test.go
+++ b/internal/integration_test.go
@@ -9,6 +9,7 @@ import (
 	"log/slog"
 	"net"
 	"net/http"
+	"os"
 	"testing"
 	"time"
 
@@ -30,6 +31,9 @@ func TestIntegration_DNSFunctionality(t *testing.T) {
 	dnsPort := getFreePort(t)
 	dotPort := getFreePort(t)
 	httpPort := getFreePort(t)
+
+	handler := slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelDebug})
+	slog.SetDefault(slog.New(handler))
 
 	// App configuration for integration test
 	app := App{

--- a/test.http
+++ b/test.http
@@ -40,7 +40,7 @@ ads.net
 POST http://admin.localhost:8080/api/blocklist/disable
 Content-Type: application/json
 
-{"duration": "PT5M"}
+{"name": "Blocklist #0", "duration": "PT5M"}
 
 ### Re-enable blocklist
 POST http://admin.localhost:8080/api/blocklist/reenable


### PR DESCRIPTION
Refactored blocklist architecture to support multiple concurrent sources

instead of a single global list. Each blocklist is now managed independently, allowing for granular status reporting and selective disabling.

```mermaid
sequenceDiagram
    participant App
    participant Updater
    participant BlockList

    App->>App: NewBlockLists()
    loop For each URL
        App->>BlockList: NewBlockList()
        App->>BlockList: Fetch()
    end
    App->>Updater: NewUpdater(blockLists)
    App->>App: NewDNSDispatcher(..., blockLists)
```

- Created `blocklist.Updater` to manage multiple `BlockList` instances.
- Updated `DNSDispatcher` to iterate through all configured lists for blocking decisions.
- Added `BlocklistHandler` endpoints for per-list status and management.