### PR TITLE
feat: include blocklist cause in dns_top_blocked_domains metric

### DIFF
--- a/internal/metrics/dns_metrics.go
+++ b/internal/metrics/dns_metrics.go
@@ -116,7 +116,7 @@ func NewDNSMetrics(cache Cache, geoIpLookup geoblock.GeoIpLookup, topK TopKConfi
 		newSpaceSaverStatsCallback(topDomains, topK.NumDomains),
 	)
 
-	topBlockedDomainsStats := NewStatsCollector("dns_top_blocked_domains", []string{"hostname"},
+	topBlockedDomainsStats := NewStatsCollector("dns_top_blocked_domains", []string{"hostname", "blocklist"},
 		fmt.Sprintf("Shows the top %d blocked domains (estimate based on count - error)", topK.NumBlocked),
 		newSpaceSaverStatsCallback(topBlockedDomains, topK.NumBlocked),
 	)

--- a/internal/metrics/request_snapshot.go
+++ b/internal/metrics/request_snapshot.go
@@ -15,12 +15,17 @@ type upstreamTTLInfo struct {
 	ttl       float64
 }
 
+type blockedDomain struct {
+	domain string
+	cause  string
+}
+
 type RequestSnapshot struct {
 	source         string
 	ipAddr         string
 	startTime      time.Time
 	primaryDomain  string
-	blockedDomains []string
+	blockedDomains []blockedDomain
 	domains        []string
 	queryCounts    []queryCountInfo
 	upstreamTTLs   []upstreamTTLInfo
@@ -78,7 +83,7 @@ func (t *RequestSnapshot) PrimaryDomain() string {
 }
 
 func (t *RequestSnapshot) AddBlockedDomain(domain string, cause string) {
-	t.blockedDomains = append(t.blockedDomains, domain)
+	t.blockedDomains = append(t.blockedDomains, blockedDomain{domain: domain, cause: cause})
 	t.blockCause = cause
 }
 
@@ -171,8 +176,8 @@ func (t *RequestSnapshot) Record(metrics *DnsMetrics) {
 		}
 		metrics.QueryCounts.WithLabelValues(qc.queryType, isBlocked).Inc()
 	}
-	for _, domain := range t.blockedDomains {
-		metrics.TopBlockedDomains.Add(domain)
+	for _, bd := range t.blockedDomains {
+		metrics.TopBlockedDomains.Add(bd.domain + "|" + bd.cause)
 	}
 	for _, domain := range t.domains {
 		metrics.TopDomains.Add(domain)


### PR DESCRIPTION
This PR adds the blocklist cause to the  metric by utilizing composite keys and updating the StatsCollector labels. 

Fixes #256.